### PR TITLE
ADD wait for disconnection to sync storage test

### DIFF
--- a/sync/storage/consumer/consumer_test.go
+++ b/sync/storage/consumer/consumer_test.go
@@ -331,6 +331,8 @@ func TestDurability(t *testing.T) {
 
 	// Stop consumer
 	cleanService()
+	// wait for disconnection
+	<-time.After(time.Duration(10 * time.Millisecond))
 
 	// Publish another one
 	err = p.Publish(context.Background(), storageSync.FileNew, file2)


### PR DESCRIPTION
- Adds 10ms wait to make sure consumer disconnected.
- Related: #7