### PR TITLE
Feature/status service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASIC_SERVICES = traefik vault localMinio cloudMinio localNats natsStreamingExporter localPrometheusPushGateway localPrometheus cloudPrometheus cloudAuth localAuth localStorage cloudStorage localNats storageSync waitlist
+BASIC_SERVICES = traefik vault localMinio cloudMinio localNats natsStreamingExporter localPrometheusPushGateway localPrometheus cloudPrometheus cloudAuth localAuth localStorage cloudStorage localNats storageSync waitlist localStatusReporter
 
 .PHONY: up run stop build
 

--- a/bin/tls/Makefile
+++ b/bin/tls/Makefile
@@ -1,6 +1,6 @@
 CDIR = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DOCKER = docker run --rm -it -v $(CDIR):/certs --entrypoint='' -w /certs cfssl/cfssl
-SERVERS = vault localMinio cloudMinio localNats
+SERVERS = vault localMinio cloudMinio localNats localStatusReporter
 PEERS = localAuth cloudAuth traefik localStorage cloudStorage waitlist
 CLIENTS = localAuthSync localNatsStreaming storageSyncConsumer localStoragePublisher localPrometheus cloudPrometheus batchStorageSync
 

--- a/bin/tls/localStatusReporter.json
+++ b/bin/tls/localStatusReporter.json
@@ -1,0 +1,20 @@
+{
+    "CN": "localStatusReporter",
+    "hosts": [
+        "127.0.0.1",
+        "localStatusReporter",
+        "status.iryo.local"
+    ],
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "SI",
+            "ST": "Kranj",
+            "L": "Kranj"
+        }
+    ]
+}
+

--- a/cmd/cloudStorage/main.go
+++ b/cmd/cloudStorage/main.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"sync"
 
@@ -18,6 +17,7 @@ import (
 
 	"github.com/iryonetwork/wwm/gen/storage/restapi"
 	"github.com/iryonetwork/wwm/gen/storage/restapi/operations"
+	logMW "github.com/iryonetwork/wwm/log"
 	APIMetrics "github.com/iryonetwork/wwm/metrics/api"
 	metricsServer "github.com/iryonetwork/wwm/metrics/server"
 	"github.com/iryonetwork/wwm/service/authorizer"
@@ -101,7 +101,7 @@ func main() {
 		WithURLSanitize(utils.WhitelistURLSanitize([]string{"storage", "versions", "sync"}))
 
 	// set handler with middlewares
-	apiHandler := apiLogMiddleware(api.Serve(nil), logger.With().Str("component", "logMW").Logger())
+	apiHandler := logMW.APILogMiddleware(api.Serve(nil), logger.With().Str("component", "logMW").Logger())
 	apiHandler = m.Middleware(apiHandler)
 
 	server.SetHandler(apiHandler)
@@ -118,7 +118,7 @@ func main() {
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
-		errCh <- metricsServer.ServePrometheusMetrics(context.Background(), ":9090", "storage")
+		errCh <- metricsServer.ServePrometheusMetrics(context.Background(), ":9090", "storage", logger.With().Str("component", "metrics/server").Logger())
 	}()
 
 	go func() {
@@ -133,13 +133,6 @@ func main() {
 			logger.Fatal().Err(err).Msg("Failed to start server")
 		}
 	}
-}
-
-func apiLogMiddleware(next http.Handler, logger zerolog.Logger) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.Debug().Str("method", r.Method).Str("path", r.URL.Path).Msg("New request")
-		next.ServeHTTP(w, r)
-	})
 }
 
 type WildcardConsumer struct{}

--- a/cmd/localAuth/main.go
+++ b/cmd/localAuth/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os"
+	"sync"
 	"time"
 
 	loads "github.com/go-openapi/loads"
@@ -15,6 +16,7 @@ import (
 	"github.com/iryonetwork/wwm/gen/auth/restapi/operations"
 	"github.com/iryonetwork/wwm/service/authSync"
 	"github.com/iryonetwork/wwm/service/authenticator"
+	statusServer "github.com/iryonetwork/wwm/status/server"
 	"github.com/iryonetwork/wwm/storage/auth"
 	"github.com/iryonetwork/wwm/utils"
 )
@@ -105,8 +107,35 @@ func main() {
 	gocron.Every(5).Minutes().Do(authSync.Sync)
 	go gocron.Start()
 
-	if err := server.Serve(); err != nil {
-		logger.Fatal().Err(err).Msg("Failed to start server")
-	}
+	// Start servers
+	errCh := make(chan error)
+	var wg sync.WaitGroup
+	go func() {
+		wg.Wait()
+		close(errCh)
+	}()
 
+	// start serving status
+	go func() {
+		wg.Add(1)
+		ss := statusServer.New(logger.With().Str("component", "status/server").Logger())
+		defer ss.Close()
+		defer wg.Done()
+
+		errCh <- ss.ListenAndServeHTTPs("localAuth:4433", "", "/certs/localAuth.pem", "/certs/localAuth-key.pem")
+	}()
+
+	// start serving API
+	go func() {
+		wg.Add(1)
+		defer server.Shutdown()
+		defer wg.Done()
+		errCh <- server.Serve()
+	}()
+
+	for err := range errCh {
+		if err != nil {
+			logger.Fatal().Err(err).Msg("Failed to start server")
+		}
+	}
 }

--- a/cmd/localStatusReporter/main.go
+++ b/cmd/localStatusReporter/main.go
@@ -80,7 +80,7 @@ func main() {
 		logger.With().Str("component", "URLPolling").Str("url", "https://cloudStorage:4433/status").Logger(),
 	)
 	cloudStorage.Start(ctx)
-	r.AddComponent(statusReporter.Cloud, "storage", localStorage)
+	r.AddComponent(statusReporter.Cloud, "storage", cloudStorage)
 	cloudAuth := polling.New(
 		polling.NewInternalURL("https://cloudAuth:4433/status", defaultTimeout),
 		pollingCfg,

--- a/cmd/localStatusReporter/main.go
+++ b/cmd/localStatusReporter/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/rs/cors"
+	"github.com/rs/zerolog"
+
+	"github.com/iryonetwork/wwm/log"
+	"github.com/iryonetwork/wwm/metrics/api"
+	metricsServer "github.com/iryonetwork/wwm/metrics/server"
+	"github.com/iryonetwork/wwm/service/statusReporter"
+	"github.com/iryonetwork/wwm/service/statusReporter/polling"
+)
+
+func main() {
+	addr := ":443"
+	metricsAddr := ":9090"
+	keyFile := "/certs/localStatusReporter-key.pem"
+	certFile := "/certs/localStatusReporter.pem"
+	defaultTimeout := time.Duration(time.Second)
+	countThreshold := 3
+	interval := time.Duration(3 * time.Second)
+	statusValidity := time.Duration(20 * time.Second)
+
+	// initialize logger
+	logger := zerolog.New(os.Stdout).With().
+		Timestamp().
+		Str("service", "localStatusReporter").
+		Logger()
+
+	// create context with cancel func
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// initialize status reporter
+	r := statusReporter.New(logger.With().Str("component", "statusReporter").Logger())
+
+	// add URL Status Polling components
+	pollingCfg := &polling.Cfg{
+		Interval:       &interval,
+		CountThreshold: &countThreshold,
+		StatusValidity: &statusValidity,
+	}
+	g := polling.New(
+		polling.NewExternalURL("https://www.google.com", defaultTimeout),
+		pollingCfg,
+		logger.With().Str("component", "URLPolling").Str("url", "https://www.google.com").Logger(),
+	)
+	g.Start(ctx)
+	r.AddComponent(statusReporter.External, "google", g)
+	n := polling.New(
+		polling.NewExternalURL("http://nna-leb.gov.lb", defaultTimeout),
+		pollingCfg,
+		logger.With().Str("component", "URLPolling").Str("url", "http://nna-leb.gov.lb").Logger(),
+	)
+	n.Start(ctx)
+	r.AddComponent(statusReporter.External, "Lebanese National News Agency", n)
+	localStorage := polling.New(
+		polling.NewInternalURL("https://localStorage:4433/status", defaultTimeout),
+		pollingCfg,
+		logger.With().Str("component", "URLPolling").Str("url", "https://localStorage:4433/status").Logger(),
+	)
+	localStorage.Start(ctx)
+	r.AddComponent(statusReporter.Local, "storage", localStorage)
+	localAuth := polling.New(
+		polling.NewInternalURL("https://localAuth:4433/status", defaultTimeout),
+		pollingCfg,
+		logger.With().Str("component", "URLPolling").Str("url", "https://localAuth:4433/status").Logger(),
+	)
+	localAuth.Start(ctx)
+	r.AddComponent(statusReporter.Local, "auth", localAuth)
+	cloudStorage := polling.New(
+		polling.NewInternalURL("https://cloudStorage:4433/status", defaultTimeout),
+		pollingCfg,
+		logger.With().Str("component", "URLPolling").Str("url", "https://cloudStorage:4433/status").Logger(),
+	)
+	cloudStorage.Start(ctx)
+	r.AddComponent(statusReporter.Cloud, "storage", localStorage)
+	cloudAuth := polling.New(
+		polling.NewInternalURL("https://cloudAuth:4433/status", defaultTimeout),
+		pollingCfg,
+		logger.With().Str("component", "URLPolling").Str("url", "https://cloudAuth:4433/status").Logger(),
+	)
+	cloudAuth.Start(ctx)
+	r.AddComponent(statusReporter.Cloud, "auth", cloudAuth)
+
+	// initialize metrics middleware
+	m := api.NewMetrics("localStatusReporter", "")
+
+	// setup handler
+	handler := cors.New(cors.Options{
+		AllowedMethods: []string{"GET"},
+		AllowedHeaders: []string{"Authorization", "Content-Type"},
+	}).Handler(m.Middleware(log.APILogMiddleware(r.Handler("status"), logger.With().Str("component", "logMW").Logger())))
+
+	server := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+
+	// Start servers
+	errCh := make(chan error)
+	var wg sync.WaitGroup
+
+	go func() {
+		wg.Wait()
+		close(errCh)
+	}()
+
+	go func() {
+		wg.Add(1)
+		defer server.Close()
+		defer wg.Done()
+		logger.Info().Msgf("Starting status reporter server at %s", addr)
+		errCh <- server.ListenAndServeTLS(certFile, keyFile)
+	}()
+
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		errCh <- metricsServer.ServePrometheusMetrics(context.Background(), metricsAddr, "status", logger.With().Str("component", "metrics/server").Logger())
+	}()
+
+	for err := range errCh {
+		if err != nil {
+			logger.Fatal().Err(err).Msg("Failed to start server")
+		}
+	}
+}

--- a/cmd/storageSync/main.go
+++ b/cmd/storageSync/main.go
@@ -101,7 +101,7 @@ func main() {
 	c.StartSubscription(storageSync.FileDelete)
 
 	go func() {
-		err := metricsServer.ServePrometheusMetrics(ctx, ":9090", "")
+		err := metricsServer.ServePrometheusMetrics(ctx, ":9090", "", logger.With().Str("component", "metrics/server").Logger())
 		if err != nil {
 			logger.Error().Err(err).Msg("prometheus metrics server failure")
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,7 +190,7 @@ services:
 
   localPrometheusPushGateway:
     image: prom/pushgateway
-    
+
   waitlist:
     build:
       context: .
@@ -202,3 +202,12 @@ services:
     - ./.data/waitlist:/data
     - ./bin/tls/waitlist-key.pem:/certs/private.key:ro
     - ./bin/tls/waitlist.pem:/certs/public.crt:ro
+
+  localStatusReporter:
+    image: golang:1.9-alpine
+    command:
+    - /wwm/localStatusReporter
+    volumes:
+    - ./.bin/:/wwm
+    - ./bin/tls:/certs:ro
+    - ./bin/tls/ca.pem:/etc/ssl/certs/ca-iryo.pem:ro

--- a/localPrometheus.yml
+++ b/localPrometheus.yml
@@ -43,6 +43,14 @@ scrape_configs:
   static_configs:
   - targets:
     - storageSync:9090
+- job_name: local_status_reporter
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /status/metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - localStatusReporter:9090
 - job_name: pushgateway
   scrape_interval: 15s
   scrape_timeout: 10s

--- a/log/middleware.go
+++ b/log/middleware.go
@@ -1,0 +1,14 @@
+package log
+
+import (
+	"net/http"
+
+	"github.com/rs/zerolog"
+)
+
+func APILogMiddleware(next http.Handler, logger zerolog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger.Debug().Str("method", r.Method).Str("path", r.URL.Path).Msg("New request")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/service/statusReporter/polling/polling.go
+++ b/service/statusReporter/polling/polling.go
@@ -1,6 +1,6 @@
 package polling
 
-//go:generate sh ../../../bin/mockgen.sh service/statusReporter/polling URLStatusEndpoint $GOFILE
+//go:generate ../../../bin/mockgen.sh service/statusReporter/polling URLStatusEndpoint $GOFILE
 
 import (
 	"context"

--- a/service/statusReporter/polling/polling.go
+++ b/service/statusReporter/polling/polling.go
@@ -1,0 +1,159 @@
+package polling
+
+//go:generate sh ../../../bin/mockgen.sh service/statusReporter/polling URLStatusEndpoint $GOFILE
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/iryonetwork/wwm/status"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// how many failed status responsed there needs to be to mark service as failing
+	defaultCountThreshold int = 3
+	// default interval for status calls
+	defaultInterval time.Duration = time.Duration(3 * time.Second)
+	// validity of archived status responses used to determine component status
+	defaultStatusValidity time.Duration = time.Duration(30 * time.Second)
+)
+
+// URLStatusEndpoint is an interface that needs to be fulfilled by URL used by URLPollingComponent
+type URLStatusEndpoint interface {
+	String() string
+	FetchStatus() (*status.Response, error)
+}
+
+type statusEntry struct {
+	timestamp time.Time
+	response  *status.Response
+}
+
+// Cfg is a config struct for status reporter service
+type Cfg struct {
+	CountThreshold *int
+	Interval       *time.Duration
+	StatusValidity *time.Duration
+}
+
+// URLPollingComponent is a struct for URL polling status component
+type URLPollingComponent struct {
+	url            URLStatusEndpoint
+	countThreshold int
+	interval       time.Duration
+	statusValidity time.Duration
+	statusLog      []statusEntry
+	logger         zerolog.Logger
+}
+
+// Status returns status response for the URL Polling component
+func (c *URLPollingComponent) Status() *status.Response {
+	if len(c.statusLog) == 0 {
+		return nil
+	}
+
+	// initialize responsesMap
+	responsesMap := map[status.Value][]*status.Response{
+		status.OK:      []*status.Response{},
+		status.Warning: []*status.Response{},
+		status.Error:   []*status.Response{},
+	}
+
+	lastStatus := c.statusLog[0]
+	doLastStatusConsecutiveRepeatCount := true
+	lastStatusConsecutiveRepeatCount := 0
+
+	// cut statuses at validity and count them
+	for i, st := range c.statusLog {
+		if time.Since(st.timestamp) < c.statusValidity {
+			if doLastStatusConsecutiveRepeatCount && lastStatus.response.Status == st.response.Status {
+				lastStatusConsecutiveRepeatCount++
+			} else {
+				doLastStatusConsecutiveRepeatCount = false
+			}
+			responsesMap[st.response.Status] = append(responsesMap[st.response.Status], st.response)
+		} else {
+			// cut c.status as the rest is not valid anymore and break the loop
+			c.statusLog = c.statusLog[:i+1]
+			break
+		}
+	}
+
+	// if last status was recorded 'countThreshold' in a row then return it
+	if lastStatusConsecutiveRepeatCount >= c.countThreshold {
+		return lastStatus.response
+	}
+
+	// otherwise return most frequent status
+	count := len(responsesMap[status.OK])
+	var resp *status.Response
+	if count > 0 {
+		resp = responsesMap[status.OK][0]
+	}
+	if len(responsesMap[status.Warning]) > count {
+		count = len(responsesMap[status.Warning])
+		resp = responsesMap[status.Warning][0]
+	}
+	if len(responsesMap[status.Error]) > count {
+		count = len(responsesMap[status.Error])
+		resp = responsesMap[status.Error][0]
+	}
+
+	return resp
+}
+
+// Start starts URL polling
+func (c *URLPollingComponent) Start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(c.interval):
+				c.currentStatus()
+			}
+		}
+	}()
+}
+
+// NewURLPollingComponent returns new URL Polling status component
+func New(url URLStatusEndpoint, cfg *Cfg, logger zerolog.Logger) *URLPollingComponent {
+	c := &URLPollingComponent{
+		url:            url,
+		interval:       defaultInterval,
+		countThreshold: defaultCountThreshold,
+		statusValidity: defaultStatusValidity,
+		logger:         logger,
+	}
+
+	if cfg != nil {
+		if cfg.Interval != nil {
+			c.interval = *cfg.Interval
+		}
+		if cfg.CountThreshold != nil {
+			c.countThreshold = *cfg.CountThreshold
+		}
+		if cfg.StatusValidity != nil {
+			c.statusValidity = *cfg.StatusValidity
+		}
+	}
+
+	return c
+}
+
+func (c *URLPollingComponent) currentStatus() {
+	resp, err := c.url.FetchStatus()
+	if err != nil {
+		c.logger.Error().Err(err).Str("url", c.url.String()).Msg("failed to fetch status")
+		resp = &status.Response{Status: status.Error, Msg: fmt.Sprintf("failed to fetch status from %s", c.url)}
+	}
+
+	latest := statusEntry{
+		timestamp: time.Now(),
+		response:  resp,
+	}
+
+	c.statusLog = append([]statusEntry{latest}, c.statusLog...)
+}

--- a/service/statusReporter/polling/url.go
+++ b/service/statusReporter/polling/url.go
@@ -1,0 +1,90 @@
+package polling
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/iryonetwork/wwm/status"
+)
+
+// ExternalURL is type for external service availability endpoint URL
+type ExternalURL struct {
+	url     string
+	timeout time.Duration
+}
+
+func (u ExternalURL) FetchStatus() (*status.Response, error) {
+	client := http.Client{Timeout: u.timeout}
+	resp, err := client.Get(u.url)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	statusResp := status.Response{Status: status.OK}
+
+	if resp.StatusCode != http.StatusOK {
+		statusResp = status.Response{Status: status.Warning, Msg: fmt.Sprintf("unexpected response code: %d", resp.StatusCode)}
+	}
+
+	return &statusResp, nil
+}
+
+func (u ExternalURL) String() string {
+	return string(u.url)
+}
+
+// InternalURL is type for internal service status endpoint URL
+type InternalURL struct {
+	ExternalURL
+}
+
+func (u InternalURL) FetchStatus() (*status.Response, error) {
+	client := http.Client{Timeout: u.timeout}
+	resp, err := client.Get(u.url)
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	statusResp := status.Response{}
+	if resp.StatusCode != http.StatusOK {
+		statusResp = status.Response{Status: status.Error, Msg: fmt.Sprintf("unexpected response code: %d", resp.StatusCode)}
+	}
+
+	err = json.Unmarshal(body, &statusResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusResp.Status.Int() == -1 {
+		// invalid status code, turn into error
+		statusResp.Msg = fmt.Sprintf("invalid status value \"%s\"", statusResp.Status)
+		statusResp.Status = status.Error
+	}
+
+	return &statusResp, nil
+}
+
+func NewExternalURL(url string, timeout time.Duration) URLStatusEndpoint {
+	return &ExternalURL{url: url, timeout: timeout}
+}
+
+func NewInternalURL(url string, timeout time.Duration) URLStatusEndpoint {
+	return &InternalURL{ExternalURL{url: url, timeout: timeout}}
+}

--- a/service/statusReporter/reporter.go
+++ b/service/statusReporter/reporter.go
@@ -1,0 +1,154 @@
+package statusReporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/rs/zerolog"
+
+	"github.com/iryonetwork/wwm/status"
+)
+
+// type for environment group name
+type Environment string
+
+// Environment values
+const (
+	Local    Environment = "local"
+	Cloud    Environment = "cloud"
+	External Environment = "external"
+)
+
+// Respone defines status reporter response
+type Response struct {
+	Status   status.Value     `json:"status"`
+	Local    *status.Response `json:"local,omitempty"`
+	Cloud    *status.Response `json:"cloud,omitempty"`
+	External *status.Response `json:"external,omitempty"`
+}
+
+type StatusReporter struct {
+	ctx      context.Context
+	cloud    map[string]status.Component
+	local    map[string]status.Component
+	external map[string]status.Component
+	logger   zerolog.Logger
+}
+
+// Status returns status response
+func (r *StatusReporter) Status() *Response {
+	st := status.OK
+
+	localResp := r.EnvironmentStatus(Local)()
+	if localResp != nil && localResp.Status.Int() > st.Int() {
+		st = localResp.Status
+	}
+
+	// cloud and external error trigger warning
+	cloudResp := r.EnvironmentStatus(Cloud)()
+	if cloudResp != nil && cloudResp.Status.Int() > st.Int() {
+		st = status.Warning
+	}
+	externalResp := r.EnvironmentStatus(External)()
+	if externalResp != nil && externalResp.Status.Int() > st.Int() {
+		st = status.Warning
+	}
+
+	return &Response{
+		Status:   st,
+		Local:    localResp,
+		Cloud:    cloudResp,
+		External: externalResp,
+	}
+}
+
+// EnvironmentStatus returns Status function for environment
+func (r *StatusReporter) EnvironmentStatus(env Environment) func() *status.Response {
+	var components map[string]status.Component
+	switch env {
+	case Cloud:
+		components = r.cloud
+	case Local:
+		components = r.local
+	case External:
+		components = r.external
+	}
+
+	return func() *status.Response {
+		if len(components) == 0 {
+			return nil
+		}
+
+		st := status.OK
+		componentsResp := make(map[string]*status.Response)
+
+		for id, c := range components {
+			resp := c.Status()
+			if resp != nil {
+				if resp.Status.Int() > st.Int() {
+					st = resp.Status
+				}
+				componentsResp[id] = resp
+			}
+		}
+
+		return &status.Response{
+			Status:     st,
+			Components: componentsResp,
+		}
+	}
+}
+
+// AddURLComponent adds status component to the reporter
+func (r *StatusReporter) AddComponent(env Environment, id string, c status.Component) {
+	switch env {
+	case Local:
+		r.local[id] = c
+	case Cloud:
+		r.cloud[id] = c
+	case External:
+		r.external[id] = c
+	}
+}
+
+// Handler returns http.Handler to facilitate HTTP server of status reporter with JSON responses
+func (r *StatusReporter) Handler(prefix string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/%s", prefix), handlerFunc(func() interface{} { return r.Status() }))
+	mux.HandleFunc(fmt.Sprintf("/%s/%s", prefix, Local), handlerFunc(func() interface{} { return r.EnvironmentStatus(Local) }))
+	mux.HandleFunc(fmt.Sprintf("/%s/%s", prefix, Cloud), handlerFunc(func() interface{} { return r.EnvironmentStatus(Cloud) }))
+	mux.HandleFunc(fmt.Sprintf("/%s/%s", prefix, External), handlerFunc(func() interface{} { return r.EnvironmentStatus(External) }))
+
+	return mux
+}
+
+// handlerFunc is a generic handler to faciliate StatusReporter HTTP serving with JSON responses
+func handlerFunc(f func() interface{}) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		status := f()
+		if status == nil {
+			rw.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		rw.WriteHeader(http.StatusOK)
+		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
+		json.NewEncoder(rw).Encode(f())
+	}
+}
+
+// NewStatusReporter returns instance of status reporter service
+func New(logger zerolog.Logger) *StatusReporter {
+	return &StatusReporter{
+		local:    make(map[string]status.Component),
+		cloud:    make(map[string]status.Component),
+		external: make(map[string]status.Component),
+		logger:   logger,
+	}
+}

--- a/service/statusReporter/reporter_test.go
+++ b/service/statusReporter/reporter_test.go
@@ -1,0 +1,274 @@
+package statusReporter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
+
+	"github.com/iryonetwork/wwm/service/statusReporter/polling"
+	"github.com/iryonetwork/wwm/service/statusReporter/polling/mock"
+	"github.com/iryonetwork/wwm/status"
+)
+
+var (
+	// interval for status calls in tests
+	interval = time.Duration(2 * time.Millisecond)
+)
+
+func TestStatus(t *testing.T) {
+	testCases := []struct {
+		description    string
+		cfg            *polling.Cfg
+		localN         int
+		cloudN         int
+		externalN      int
+		mockCalls      func(local, cloud, external []*mock.MockURLStatusEndpoint, called chan bool) []*gomock.Call
+		expectedCallsN int
+		expected       *Response
+	}{
+		{
+			"status.OK: no components added",
+			&polling.Cfg{Interval: &interval},
+			0,
+			0,
+			0,
+			func(local, cloud, external []*mock.MockURLStatusEndpoint, called chan bool) []*gomock.Call {
+				return []*gomock.Call{}
+			},
+			0,
+			&Response{Status: status.OK},
+		},
+		{
+			"status.OK: all components passing",
+			&polling.Cfg{Interval: &interval},
+			2,
+			2,
+			1,
+			func(local, cloud, external []*mock.MockURLStatusEndpoint, called chan bool) []*gomock.Call {
+				var mockCalls []*gomock.Call
+				for _, l := range local {
+					mockCalls = append(mockCalls, l.EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil))
+				}
+				for _, c := range cloud {
+					mockCalls = append(mockCalls, c.EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil))
+				}
+				for _, e := range external {
+					mockCalls = append(mockCalls, e.EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil))
+				}
+
+				return mockCalls
+			},
+			5,
+			&Response{
+				Status: status.OK,
+				Local: &status.Response{
+					Status: status.OK,
+					Components: map[string]*status.Response{
+						"local0": &status.Response{Status: status.OK},
+						"local1": &status.Response{Status: status.OK},
+					},
+				},
+				Cloud: &status.Response{
+					Status: status.OK,
+					Components: map[string]*status.Response{
+						"cloud0": &status.Response{Status: status.OK},
+						"cloud1": &status.Response{Status: status.OK},
+					},
+				},
+				External: &status.Response{
+					Status: status.OK,
+					Components: map[string]*status.Response{
+						"external0": &status.Response{Status: status.OK},
+					},
+				},
+			},
+		},
+		{
+			"status.OK: warning & error returned twice",
+			&polling.Cfg{Interval: &interval},
+			1,
+			1,
+			0,
+			func(local, cloud, external []*mock.MockURLStatusEndpoint, called chan bool) []*gomock.Call {
+				var mockCalls []*gomock.Call
+				mockCalls = append(mockCalls, local[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil).Times(2))
+				mockCalls = append(mockCalls, local[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Warning}, nil).Times(2))
+				mockCalls = append(mockCalls, cloud[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil).Times(2))
+				mockCalls = append(mockCalls, cloud[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Error}, nil).Times(2))
+
+				return mockCalls
+			},
+			8,
+			&Response{
+				Status: status.OK,
+				Local: &status.Response{
+					Status: status.OK,
+					Components: map[string]*status.Response{
+						"local0": &status.Response{Status: status.OK},
+					},
+				},
+				Cloud: &status.Response{
+					Status: status.OK,
+					Components: map[string]*status.Response{
+						"cloud0": &status.Response{Status: status.OK},
+					},
+				},
+			},
+		},
+		{
+			"status.Warning, status.Error, status.OK: last statuses count threshold rule",
+			&polling.Cfg{Interval: &interval},
+			1,
+			2,
+			0,
+			func(local, cloud, external []*mock.MockURLStatusEndpoint, called chan bool) []*gomock.Call {
+				var mockCalls []*gomock.Call
+				mockCalls = append(mockCalls, local[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil).Times(5))
+				mockCalls = append(mockCalls, local[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Warning}, nil).Times(3))
+				mockCalls = append(mockCalls, cloud[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil).Times(5))
+				mockCalls = append(mockCalls, cloud[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Error}, nil).Times(3))
+				mockCalls = append(mockCalls, cloud[1].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Warning}, nil).Times(5))
+				mockCalls = append(mockCalls, cloud[1].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil).Times(3))
+
+				return mockCalls
+			},
+			24,
+			&Response{
+				Status: status.Warning,
+				Local: &status.Response{
+					Status: status.Warning,
+					Components: map[string]*status.Response{
+						"local0": &status.Response{Status: status.Warning},
+					},
+				},
+				Cloud: &status.Response{
+					Status: status.Error,
+					Components: map[string]*status.Response{
+						"cloud0": &status.Response{Status: status.Error},
+						"cloud1": &status.Response{Status: status.OK},
+					},
+				},
+			},
+		},
+		{
+			"status.Warning, status.Error, status.OK: majority rule",
+			&polling.Cfg{Interval: &interval},
+			1,
+			2,
+			0,
+			func(local, cloud, external []*mock.MockURLStatusEndpoint, called chan bool) []*gomock.Call {
+				var mockCalls []*gomock.Call
+				mockCalls = append(mockCalls, local[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Warning}, nil).Times(5))
+				mockCalls = append(mockCalls, local[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil).Times(2))
+				mockCalls = append(mockCalls, cloud[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Error}, nil).Times(5))
+				mockCalls = append(mockCalls, cloud[0].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Warning}, nil).Times(2))
+				mockCalls = append(mockCalls, cloud[1].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.OK}, nil).Times(5))
+				mockCalls = append(mockCalls, cloud[1].EXPECT().FetchStatus().Do(func() { called <- true }).Return(&status.Response{Status: status.Error}, nil).Times(2))
+
+				return mockCalls
+			},
+			21,
+			&Response{
+				Status: status.Warning,
+				Local: &status.Response{
+					Status: status.Warning,
+					Components: map[string]*status.Response{
+						"local0": &status.Response{Status: status.Warning},
+					},
+				},
+				Cloud: &status.Response{
+					Status: status.Error,
+					Components: map[string]*status.Response{
+						"cloud0": &status.Response{Status: status.Error},
+						"cloud1": &status.Response{Status: status.OK},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			// get status reporter
+			s := New(zerolog.New(os.Stdout))
+
+			// get mock url status endpoints
+			local, cloud, external, cleanup := getMockURLStatusEndpoints(t, test.localN, test.cloudN, test.externalN)
+			defer cleanup()
+
+			// mock calls
+			ch := make(chan bool)
+			test.mockCalls(local, cloud, external, ch)
+
+			// add components to service, run mock calls and start polling
+			ctx, cancel := context.WithCancel(context.Background())
+			for i, url := range local {
+				p := polling.New(url, test.cfg, zerolog.New(os.Stdout))
+				s.AddComponent(Local, fmt.Sprintf("local%d", i), p)
+				p.Start(ctx)
+			}
+			for i, url := range cloud {
+				p := polling.New(url, test.cfg, zerolog.New(os.Stdout))
+				s.AddComponent(Cloud, fmt.Sprintf("cloud%d", i), p)
+				p.Start(ctx)
+			}
+			for i, url := range external {
+				p := polling.New(url, test.cfg, zerolog.New(os.Stdout))
+				s.AddComponent(External, fmt.Sprintf("external%d", i), p)
+				p.Start(ctx)
+			}
+
+			// wait for all the mock calls to be completed and then cancel context to stop polling
+			for i := 0; i < test.expectedCallsN; i++ {
+				select {
+				case <-ch:
+				// do nothing
+				case <-time.After(time.Second):
+					t.Fatal("waiting too long for expected mock call")
+				}
+			}
+			// wait just a bit longer to make sure all statuses were recorded
+			<-time.After(50 * time.Microsecond)
+			cancel()
+			// wait a bit to test context cancellation
+			<-time.After(interval)
+
+			resp := s.Status()
+
+			// check expected results
+			if !reflect.DeepEqual(resp, test.expected) {
+				t.Errorf("Expected list to equal\n%+v\ngot\n%+v", test.expected, resp)
+			}
+		})
+	}
+}
+
+func getMockURLStatusEndpoints(t *testing.T, localN, cloudN, externalN int) ([]*mock.MockURLStatusEndpoint, []*mock.MockURLStatusEndpoint, []*mock.MockURLStatusEndpoint, func()) {
+	ctrl := gomock.NewController(t)
+	cleanup := func() {
+		ctrl.Finish()
+	}
+
+	var local, cloud, external []*mock.MockURLStatusEndpoint
+
+	for i := 0; i < localN; i++ {
+		url := mock.NewMockURLStatusEndpoint(ctrl)
+		local = append(local, url)
+	}
+	for i := 0; i < cloudN; i++ {
+		url := mock.NewMockURLStatusEndpoint(ctrl)
+		cloud = append(cloud, url)
+	}
+	for i := 0; i < externalN; i++ {
+		url := mock.NewMockURLStatusEndpoint(ctrl)
+		external = append(external, url)
+	}
+
+	return local, cloud, external, cleanup
+}

--- a/service/statusReporter/reporter_test.go
+++ b/service/statusReporter/reporter_test.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// interval for status calls in tests
-	interval = time.Duration(2 * time.Millisecond)
+	interval = time.Duration(5 * time.Millisecond)
 )
 
 func TestStatus(t *testing.T) {

--- a/status/server/status.go
+++ b/status/server/status.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/rs/zerolog"
+
+	"github.com/iryonetwork/wwm/log"
+	"github.com/iryonetwork/wwm/metrics/api"
+	"github.com/iryonetwork/wwm/status"
+)
+
+type statusServer struct {
+	components map[string]status.Component
+	server     *http.Server
+	logger     zerolog.Logger
+}
+
+// AddService adds component to be checked on status call
+func (s *statusServer) AddComponent(name string, component status.Component) {
+	s.components[name] = component
+}
+
+// Status returns status response
+func (s *statusServer) Status() *status.Response {
+	currentStatus := status.OK
+	componentsResp := make(map[string]*status.Response)
+	for id, c := range s.components {
+		cResp := c.Status()
+
+		// higher the StatusValue the worse the status, combined response will return worst status of all components
+		if cResp != nil && cResp.Status.Int() > currentStatus.Int() {
+			currentStatus = cResp.Status
+		}
+		componentsResp[id] = cResp
+	}
+
+	return &status.Response{
+		Status:     currentStatus,
+		Components: componentsResp,
+	}
+}
+
+// ServeHTTP serves status API response
+func (s *statusServer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	rw.Header().Set("Content-Type", "application/json; charset=utf-8")
+	json.NewEncoder(rw).Encode(s.Status())
+}
+
+// ListenAndServeHTTP starts serving status endpoint
+func (s *statusServer) ListenAndServeHTTPs(addr string, namespace string, certFile, keyFile string) error {
+	if s.server != nil {
+		s.server.Close()
+	}
+
+	// initialize metrics middleware
+	m := api.NewMetrics("status", "")
+
+	path := "/status"
+	if namespace != "" {
+		path = fmt.Sprintf("/%s/status", namespace)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle(path, s)
+	s.server = &http.Server{
+		Addr:    addr,
+		Handler: m.Middleware(log.APILogMiddleware(mux, s.logger.With().Str("component", "logMW").Logger())),
+	}
+
+	s.logger.Info().Msgf("Starting status server at %s%s", addr, path)
+
+	return s.server.ListenAndServeTLS(certFile, keyFile)
+}
+
+func (s *statusServer) Close() error {
+	return s.server.Close()
+}
+
+func New(logger zerolog.Logger) *statusServer {
+	components := make(map[string]status.Component)
+
+	return &statusServer{logger: logger, components: components}
+}

--- a/status/server/status_test.go
+++ b/status/server/status_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
+
+	"github.com/iryonetwork/wwm/status"
+	"github.com/iryonetwork/wwm/status/mock"
+)
+
+func TestStatus(t *testing.T) {
+	testCases := []struct {
+		description string
+		mockCalls   func(s1, s2, s3 *mock.MockComponent) []*gomock.Call
+		expected    *status.Response
+	}{
+		{
+			"status.OK: all services are ok",
+			func(s1, s2, s3 *mock.MockComponent) []*gomock.Call {
+				return []*gomock.Call{
+					s1.EXPECT().Status().Return(&status.Response{Status: status.OK}),
+					s2.EXPECT().Status().Return(&status.Response{Status: status.OK}),
+					s3.EXPECT().Status().Return(&status.Response{Status: status.OK}),
+				}
+			},
+			&status.Response{
+				Status: status.OK,
+				Components: map[string]*status.Response{
+					"s1": &status.Response{Status: status.OK},
+					"s2": &status.Response{Status: status.OK},
+					"s3": &status.Response{Status: status.OK},
+				},
+			},
+		},
+		{
+			"status.Warning: one service has warning status",
+			func(s1, s2, s3 *mock.MockComponent) []*gomock.Call {
+				return []*gomock.Call{
+					s1.EXPECT().Status().Return(&status.Response{Status: status.OK}),
+					s2.EXPECT().Status().Return(&status.Response{Status: status.Warning}),
+					s3.EXPECT().Status().Return(&status.Response{Status: status.OK}),
+				}
+			},
+			&status.Response{
+				Status: status.Warning,
+				Components: map[string]*status.Response{
+					"s1": &status.Response{Status: status.OK},
+					"s2": &status.Response{Status: status.Warning},
+					"s3": &status.Response{Status: status.OK},
+				},
+			},
+		},
+		{
+			"status.Error: one service has error status",
+			func(s1, s2, s3 *mock.MockComponent) []*gomock.Call {
+				return []*gomock.Call{
+					s1.EXPECT().Status().Return(&status.Response{Status: status.Error}),
+					s2.EXPECT().Status().Return(&status.Response{Status: status.Warning}),
+					s3.EXPECT().Status().Return(&status.Response{Status: status.OK}),
+				}
+			},
+			&status.Response{
+				Status: status.Error,
+				Components: map[string]*status.Response{
+					"s1": &status.Response{Status: status.Error},
+					"s2": &status.Response{Status: status.Warning},
+					"s3": &status.Response{Status: status.OK},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			// get mock status services
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			s1 := mock.NewMockComponent(ctrl)
+			s2 := mock.NewMockComponent(ctrl)
+			s3 := mock.NewMockComponent(ctrl)
+
+			// get status service
+			s := New(zerolog.New(os.Stdout))
+			s.AddComponent("s1", s1)
+			s.AddComponent("s2", s2)
+			s.AddComponent("s3", s3)
+
+			test.mockCalls(s1, s2, s3)
+
+			// call Status()
+			status := s.Status()
+
+			// check expected results
+			if !reflect.DeepEqual(status, test.expected) {
+				fmt.Println("Expected")
+				printJson(test.expected)
+				fmt.Println("Got")
+				printJson(status)
+				t.Errorf("Expected list to equal\n%+v\ngot\n%+v", test.expected, status)
+			}
+
+		})
+	}
+}
+
+func printJson(item interface{}) {
+	enc := json.NewEncoder(os.Stdout)
+	_ = enc.Encode(item)
+}

--- a/status/server/status_test.go
+++ b/status/server/status_test.go
@@ -21,7 +21,7 @@ func TestStatus(t *testing.T) {
 		expected    *status.Response
 	}{
 		{
-			"status.OK: all services are ok",
+			"status.OK: all components are ok",
 			func(s1, s2, s3 *mock.MockComponent) []*gomock.Call {
 				return []*gomock.Call{
 					s1.EXPECT().Status().Return(&status.Response{Status: status.OK}),
@@ -39,7 +39,7 @@ func TestStatus(t *testing.T) {
 			},
 		},
 		{
-			"status.Warning: one service has warning status",
+			"status.Warning: one component has warning status",
 			func(s1, s2, s3 *mock.MockComponent) []*gomock.Call {
 				return []*gomock.Call{
 					s1.EXPECT().Status().Return(&status.Response{Status: status.OK}),
@@ -57,7 +57,7 @@ func TestStatus(t *testing.T) {
 			},
 		},
 		{
-			"status.Error: one service has error status",
+			"status.Error: one component has error status",
 			func(s1, s2, s3 *mock.MockComponent) []*gomock.Call {
 				return []*gomock.Call{
 					s1.EXPECT().Status().Return(&status.Response{Status: status.Error}),

--- a/status/status.go
+++ b/status/status.go
@@ -1,6 +1,6 @@
 package status
 
-//go:generate sh ../bin/mockgen.sh status Server,Component $GOFILE
+//go:generate sh ../bin/mockgen.sh status Component $GOFILE
 
 type Value string
 

--- a/status/status.go
+++ b/status/status.go
@@ -1,6 +1,6 @@
 package status
 
-//go:generate sh ../bin/mockgen.sh status Component $GOFILE
+//go:generate ../bin/mockgen.sh status Component $GOFILE
 
 type Value string
 

--- a/status/status.go
+++ b/status/status.go
@@ -1,0 +1,37 @@
+package status
+
+//go:generate sh ../bin/mockgen.sh status Server,Component $GOFILE
+
+type Value string
+
+// Status values
+const (
+	OK      Value = "ok"
+	Warning       = "warning"
+	Error         = "error"
+)
+
+type Response struct {
+	Status     Value                `json:"status"`
+	Msg        string               `json:"description,omitempty"`
+	Components map[string]*Response `json:"components,omitempty"`
+}
+
+func (s Value) Int() int8 {
+	switch s {
+	case OK:
+		return 0
+	case Warning:
+		return 1
+	case Error:
+		return 2
+	}
+
+	// invalid status value
+	return -1
+}
+
+// Component is an interface for a component that exposes its status
+type Component interface {
+	Status() *Response
+}

--- a/traefik.toml
+++ b/traefik.toml
@@ -92,6 +92,14 @@ address = ":8080"
     [backends.localPrometheusPushGateway.servers.server1]
     url = "http://localPrometheusPushGateway:9091"
 
+  [backends.localStatusReporter]
+    [backends.localStatusReporter.servers.server1]
+    url = "https://localStatusReporter"
+
+  [backends.localStatusReporterMetrics]
+    [backends.localStatusReporterMetrics.servers.server1]
+    url = "http://localStatusReporterMetrics:9090"
+
 [frontends]
   [frontends.localauth]
   backend = "localauth"
@@ -167,3 +175,8 @@ address = ":8080"
   backend = "cloudPrometheus"
     [frontends.cloudPrometheus.routes.route1]
     rule = "Host:prometheus.iryo.cloud"
+
+  [frontends.localStatus]
+  backend = "localStatusReporter"
+    [frontends.localStatus.routes.route1]
+    rule = "Host:iryo.local;PathPrefix:/status"

--- a/traefik.toml
+++ b/traefik.toml
@@ -27,14 +27,22 @@ address = ":8080"
     [backends.localauthMetrics.servers.server1]
     url = "http://localAuth:9090"
 
-  [backends.localstorage]
-    [backends.localstorage.servers.server1]
-    url = "https://localStorage"
+  [backends.localauthStatus]
+    [backends.localauthStatus.servers.server1]
+    url = "http://localAuth:4433"
 
   [backends.cloudauth]
     [backends.cloudauth.servers.server1]
     url = "https://cloudAuth"
     weight = 10
+
+  [backends.cloudauthStatus]
+    [backends.cloudauthStatus.servers.server1]
+    url = "http://cloudAuth:4433"
+
+  [backends.localstorage]
+    [backends.localstorage.servers.server1]
+    url = "https://localStorage"
 
   [backends.localstorageMetrics]
     [backends.localstorageMetrics.servers.server1]
@@ -43,6 +51,10 @@ address = ":8080"
   [backends.waitlist]
     [backends.waitlist.servers.server1]
     url = "https://waitlist"
+
+  [backends.localstorageStatus]
+    [backends.localstorageStatus.servers.server1]
+    url = "https://localStorage:4433"
 
   [backends.localMinio]
     [backends.localMinio.servers.server1]
@@ -55,6 +67,10 @@ address = ":8080"
   [backends.cloudstorageMetrics]
     [backends.cloudstorageMetrics.servers.server1]
     url = "http://cloudStorage:9090"
+
+  [backends.cloudstorageStatus]
+    [backends.cloudstorageStatus.servers.server1]
+    url = "https://cloudStorage:4433"
 
   [backends.cloudMinio]
     [backends.cloudMinio.servers.server1]


### PR DESCRIPTION
- Adds a status package for exposing status of a service. For now it just acts for as "ping" endpoint for services that have it added but can be expanded, also with granular information, e.g. connection to db etc.
- Adds statusReporter service that gathers statuses from configured URLs and exposes in single JSON response. 
- StatusReporter polls endpoints with regular interval and reports current status based on history of responses in configure timespan.
      - If three last status responses were the same it's the current status.
      - If they are different, most common responses over configured timespan
        (statusValidity) is returned

- Example statusReporter response:
`{"status":"warning","local":{"status":"ok","components":{"auth":{"status":"ok"},"storage":{"status":"ok"}}},"cloud":{"status":"error","components":{"auth":{"status":"ok"},"storage":{"status":"error","description":"unexpected response code: 404"}}},"external":{"status":"ok","components":{"Lebanese National News Agency":{"status":"ok"},"google":{"status":"ok"}}}}`