### PR TITLE
Issue/add context

### DIFF
--- a/service/storage/handlers.go
+++ b/service/storage/handlers.go
@@ -38,7 +38,7 @@ type handlers struct {
 
 func (h *handlers) FileList() operations.FileListHandler {
 	return operations.FileListHandlerFunc(func(params operations.FileListParams, principal *string) middleware.Responder {
-		list, err := h.service.FileList(params.Bucket)
+		list, err := h.service.FileList(params.HTTPRequest.Context(), params.Bucket)
 		if err != nil {
 			return operations.NewFileListInternalServerError().WithPayload(&models.Error{
 				Code:    "server_error",
@@ -55,7 +55,7 @@ func (h *handlers) FileList() operations.FileListHandler {
 
 func (h *handlers) FileGet() operations.FileGetHandler {
 	return operations.FileGetHandlerFunc(func(params operations.FileGetParams, principal *string) middleware.Responder {
-		r, fd, err := h.service.FileGet(params.Bucket, params.FileID)
+		r, fd, err := h.service.FileGet(params.HTTPRequest.Context(), params.Bucket, params.FileID)
 		if err != nil {
 			switch err {
 			case ErrNotFound:
@@ -82,7 +82,7 @@ func (h *handlers) FileGet() operations.FileGetHandler {
 
 func (h *handlers) FileGetVersion() operations.FileGetVersionHandler {
 	return operations.FileGetVersionHandlerFunc(func(params operations.FileGetVersionParams, principal *string) middleware.Responder {
-		r, fd, err := h.service.FileGetVersion(params.Bucket, params.FileID, params.Version)
+		r, fd, err := h.service.FileGetVersion(params.HTTPRequest.Context(), params.Bucket, params.FileID, params.Version)
 		if err != nil {
 			switch err {
 			case ErrNotFound:
@@ -109,7 +109,7 @@ func (h *handlers) FileGetVersion() operations.FileGetVersionHandler {
 
 func (h *handlers) FileListVersions() operations.FileListVersionsHandler {
 	return operations.FileListVersionsHandlerFunc(func(params operations.FileListVersionsParams, principal *string) middleware.Responder {
-		list, err := h.service.FileListVersions(params.Bucket, params.FileID)
+		list, err := h.service.FileListVersions(params.HTTPRequest.Context(), params.Bucket, params.FileID)
 		if err != nil {
 			return operations.NewFileListVersionsInternalServerError().WithPayload(&models.Error{
 				Code:    "server_error",
@@ -133,7 +133,7 @@ func (h *handlers) FileNew() operations.FileNewHandler {
 		defer params.File.Close()
 
 		// call service
-		fd, err := h.service.FileNew(params.Bucket, params.File, params.ContentType, archetype)
+		fd, err := h.service.FileNew(params.HTTPRequest.Context(), params.Bucket, params.File, params.ContentType, archetype)
 		if err != nil {
 			return operations.NewFileNewInternalServerError().WithPayload(&models.Error{
 				Code:    "server_error",
@@ -154,7 +154,7 @@ func (h *handlers) FileUpdate() operations.FileUpdateHandler {
 		defer params.File.Close()
 
 		// call service
-		fd, err := h.service.FileUpdate(params.Bucket, params.FileID, params.File, params.ContentType, archetype)
+		fd, err := h.service.FileUpdate(params.HTTPRequest.Context(), params.Bucket, params.FileID, params.File, params.ContentType, archetype)
 		if err != nil {
 			switch err {
 			case ErrNotFound:
@@ -173,7 +173,7 @@ func (h *handlers) FileUpdate() operations.FileUpdateHandler {
 
 func (h *handlers) FileDelete() operations.FileDeleteHandler {
 	return operations.FileDeleteHandlerFunc(func(params operations.FileDeleteParams, principal *string) middleware.Responder {
-		err := h.service.FileDelete(params.Bucket, params.FileID)
+		err := h.service.FileDelete(params.HTTPRequest.Context(), params.Bucket, params.FileID)
 		if err != nil {
 			switch err {
 			case ErrNotFound:
@@ -192,7 +192,7 @@ func (h *handlers) FileDelete() operations.FileDeleteHandler {
 
 func (h *handlers) SyncBucketList() operations.SyncBucketListHandler {
 	return operations.SyncBucketListHandlerFunc(func(params operations.SyncBucketListParams, principal *string) middleware.Responder {
-		list, err := h.service.BucketList()
+		list, err := h.service.BucketList(params.HTTPRequest.Context())
 		if err != nil {
 			return operations.NewSyncBucketListInternalServerError().WithPayload(&models.Error{
 				Code:    "server_error",
@@ -209,7 +209,7 @@ func (h *handlers) SyncBucketList() operations.SyncBucketListHandler {
 
 func (h *handlers) SyncFileList() operations.SyncFileListHandler {
 	return operations.SyncFileListHandlerFunc(func(params operations.SyncFileListParams, principal *string) middleware.Responder {
-		list, err := h.service.SyncFileList(params.Bucket)
+		list, err := h.service.SyncFileList(params.HTTPRequest.Context(), params.Bucket)
 		if err != nil {
 			return operations.NewSyncFileListInternalServerError().WithPayload(&models.Error{
 				Code:    "server_error",
@@ -226,7 +226,7 @@ func (h *handlers) SyncFileList() operations.SyncFileListHandler {
 
 func (h *handlers) SyncFileListVersions() operations.SyncFileListVersionsHandler {
 	return operations.SyncFileListVersionsHandlerFunc(func(params operations.SyncFileListVersionsParams, principal *string) middleware.Responder {
-		list, err := h.service.FileListVersions(params.Bucket, params.FileID)
+		list, err := h.service.FileListVersions(params.HTTPRequest.Context(), params.Bucket, params.FileID)
 		if err != nil {
 			return operations.NewSyncFileListVersionsInternalServerError().WithPayload(&models.Error{
 				Code:    "server_error",
@@ -243,7 +243,7 @@ func (h *handlers) SyncFileListVersions() operations.SyncFileListVersionsHandler
 
 func (h *handlers) SyncFileMetadata() operations.SyncFileMetadataHandler {
 	return operations.SyncFileMetadataHandlerFunc(func(params operations.SyncFileMetadataParams, principal *string) middleware.Responder {
-		_, fd, err := h.service.FileGetVersion(params.Bucket, params.FileID, params.Version)
+		_, fd, err := h.service.FileGetVersion(params.HTTPRequest.Context(), params.Bucket, params.FileID, params.Version)
 		if err != nil {
 			switch err {
 			case ErrNotFound:
@@ -271,7 +271,7 @@ func (h *handlers) SyncFile() operations.SyncFileHandler {
 
 		// call service
 		archetype := swag.StringValue(params.Archetype)
-		fd, err := h.service.SyncFile(params.Bucket, params.FileID, params.Version, params.File, params.ContentType, params.Created, archetype)
+		fd, err := h.service.SyncFile(params.HTTPRequest.Context(), params.Bucket, params.FileID, params.Version, params.File, params.ContentType, params.Created, archetype)
 		if err != nil {
 			switch err {
 			case ErrAlreadyExists:
@@ -292,7 +292,7 @@ func (h *handlers) SyncFile() operations.SyncFileHandler {
 
 func (h *handlers) SyncFileDelete() operations.SyncFileDeleteHandler {
 	return operations.SyncFileDeleteHandlerFunc(func(params operations.SyncFileDeleteParams, principal *string) middleware.Responder {
-		err := h.service.SyncFileDelete(params.Bucket, params.FileID, params.Version, params.Created)
+		err := h.service.SyncFileDelete(params.HTTPRequest.Context(), params.Bucket, params.FileID, params.Version, params.Created)
 		if err != nil {
 			switch err {
 			case ErrNotFound:

--- a/storage/s3/minio.go
+++ b/storage/s3/minio.go
@@ -1,7 +1,9 @@
 package s3
 
 import (
-	"github.com/iryonetwork/wwm/storage/s3/object"
+	"context"
+	"io"
+
 	minio "github.com/minio/minio-go"
 )
 
@@ -10,8 +12,8 @@ type iminio struct {
 	minio.Client
 }
 
-func (m iminio) GetObject(bucketName, objectName string, opts minio.GetObjectOptions) (object.Object, error) {
-	return m.Client.GetObject(bucketName, objectName, opts)
+func (m iminio) GetObjectWithContext(ctx context.Context, bucketName, objectName string, opts minio.GetObjectOptions) (io.ReadCloser, error) {
+	return m.Client.GetObjectWithContext(ctx, bucketName, objectName, opts)
 }
 
 // BucketExists is a wrapper for original BucketExists method to fix incorrect handling of 404 returned as response

--- a/storage/s3/object/object.go
+++ b/storage/s3/object/object.go
@@ -17,6 +17,7 @@ import (
 type Object interface {
 	Stat() (minio.ObjectInfo, error)
 	Read(b []byte) (n int, err error)
+	Close() (err error)
 }
 
 // NewObjectInfo holds data required to create a new file


### PR DESCRIPTION
ADD context to storage API
    
    - Storage API is generated now with context passed to handlers.
    - Context is accepted in methods of:
      - storage handlers
      - service
      - s3 storage package.
    - Context is passed to minio package methods that accept it.
    - Related: #7