### PR TITLE
Storage API fixes

### DIFF
--- a/docs/api/storage.yml
+++ b/docs/api/storage.yml
@@ -174,7 +174,7 @@ paths:
               description: File's full path
             X-Labels:
               type: string
-              description: Pipe-delimited file's labels
+              description: Comma-delimited file's labels
 
         403:
           $ref: '#/responses/403'
@@ -389,7 +389,7 @@ paths:
               description: File's full path
             X-Labels:
               type: string
-              description: Pipe-delimited file's labels
+              description: Comma-delimited file's labels
 
         403:
           $ref: '#/responses/403'
@@ -556,7 +556,7 @@ paths:
               description: File's full path
             X-Labels:
               type: string
-              description: Pipe-delimited file's labels
+              description: Comma-delimited file's labels
 
         403:
           description: Forbidden

--- a/docs/api/storage.yml
+++ b/docs/api/storage.yml
@@ -122,7 +122,7 @@ paths:
         - local
         - cloud
       summary: Fetch a file
-      description: Fetches the latest revision of a file
+      description: Fetches the latest revision of a file. Label can be used instead of fileID to fetch file containing list of files with given label, label files collection file is formatted as JSON array with file descriptors as items.
       operationId: fileGet
       produces:
         - application/octet-stream
@@ -291,7 +291,7 @@ paths:
         - local
         - cloud
       summary: List of versions of a file
-      description: Returns a list of available file versions
+      description: Returns a list of available file versions. Label can be used instead of fileID to fetch list of versions of label files collection file.
       operationId: fileListVersions
 
       parameters:
@@ -331,7 +331,7 @@ paths:
         - local
         - cloud
       summary: Get a specific version of file
-      description: Returns a specific version of a file
+      description: Returns a specific version of a file. Label can be used instead of fileID to fetch file containing list of files with given label, label files collection file is formatted as JSON array with file descriptors as items.
       operationId: fileGetVersion
       produces:
         - application/octet-stream

--- a/service/storage/handlers.go
+++ b/service/storage/handlers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/iryonetwork/wwm/gen/storage/models"
 	"github.com/iryonetwork/wwm/gen/storage/restapi/operations"
+	"github.com/iryonetwork/wwm/utils"
 )
 
 // Handlers describes the actions supported by the storage handlers
@@ -67,7 +68,7 @@ func (h *handlers) FileGet() operations.FileGetHandler {
 			}
 		}
 
-		return operations.NewFileGetOK().
+		return utils.UseProducer(operations.NewFileGetOK().
 			WithPayload(r).
 			WithContentType(fd.ContentType).
 			WithXCreated(fd.Created).
@@ -76,7 +77,7 @@ func (h *handlers) FileGet() operations.FileGetHandler {
 			WithXChecksum(fd.Checksum).
 			WithXName(fd.Name).
 			WithXPath(fd.Path).
-			WithXLabels(formatLabelsHeader(fd.Labels))
+			WithXLabels(formatLabelsHeader(fd.Labels)), utils.FileProducer)
 	})
 }
 
@@ -96,7 +97,7 @@ func (h *handlers) FileGetVersion() operations.FileGetVersionHandler {
 			}
 		}
 
-		return operations.NewFileGetVersionOK().
+		return utils.UseProducer(operations.NewFileGetVersionOK().
 			WithPayload(r).
 			WithContentType(fd.ContentType).
 			WithXCreated(fd.Created).
@@ -105,7 +106,7 @@ func (h *handlers) FileGetVersion() operations.FileGetVersionHandler {
 			WithXChecksum(fd.Checksum).
 			WithXName(fd.Name).
 			WithXPath(fd.Path).
-			WithXLabels(formatLabelsHeader(fd.Labels))
+			WithXLabels(formatLabelsHeader(fd.Labels)), utils.FileProducer)
 	})
 }
 

--- a/utils/producers.go
+++ b/utils/producers.go
@@ -7,18 +7,19 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 )
 
-type producers int8
+type producer int8
 
 // Producers
 const (
-	_ producers = iota
+	_ producer = iota
 	JSONProducer
 	TextProducer
 	BinProducer
+	FileProducer
 )
 
 // UseProducer is used to override which producer will be used in response
-func UseProducer(responder middleware.Responder, p producers) middleware.Responder {
+func UseProducer(responder middleware.Responder, p producer) middleware.Responder {
 	return middleware.ResponderFunc(func(rw http.ResponseWriter, pr runtime.Producer) {
 		switch p {
 		case JSONProducer:
@@ -31,6 +32,10 @@ func UseProducer(responder middleware.Responder, p producers) middleware.Respond
 
 		case BinProducer:
 			rw.Header().Set(runtime.HeaderContentType, "application/octet-stream")
+			responder.WriteResponse(rw, runtime.ByteStreamProducer())
+
+		case FileProducer:
+			// content type is expected to be set already
 			responder.WriteResponse(rw, runtime.ByteStreamProducer())
 
 		default:


### PR DESCRIPTION
- Alternative fix for problems with downloading files:
       - UPD force bytestream producer when returning file
- Storage API docs fixes:
        - Labels in header are comma-delimited, not pipe-delimited
        - Add information about fetching of collection of files with given label to storage API specs.
- Closes: #56, #61