### PR TITLE
UPD prevent concurrent casbin policy loading

### DIFF
--- a/storage/auth/clinics.go
+++ b/storage/auth/clinics.go
@@ -196,7 +196,7 @@ func (s *Storage) addClinic(clinic *models.Clinic) (*models.Clinic, error) {
 	}
 
 	if s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return addedClinic, nil
@@ -280,7 +280,7 @@ func (s *Storage) UpdateClinic(clinic *models.Clinic) (*models.Clinic, error) {
 	}
 
 	if s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return updatedClinic, nil
@@ -358,7 +358,7 @@ func (s *Storage) RemoveClinic(id string) error {
 	})
 
 	if err == nil && s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return err

--- a/storage/auth/locations.go
+++ b/storage/auth/locations.go
@@ -215,7 +215,7 @@ func (s *Storage) addLocation(location *models.Location) (*models.Location, erro
 	}
 
 	if s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return addedLocation, nil
@@ -273,7 +273,7 @@ func (s *Storage) UpdateLocation(location *models.Location) (*models.Location, e
 	}
 
 	if s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return updatedLocation, nil
@@ -389,7 +389,7 @@ func (s *Storage) RemoveLocation(id string) error {
 	})
 
 	if err == nil && s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return err

--- a/storage/auth/organizations.go
+++ b/storage/auth/organizations.go
@@ -207,7 +207,7 @@ func (s *Storage) addOrganization(organization *models.Organization) (*models.Or
 	}
 
 	if s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return addedOrganization, nil
@@ -267,7 +267,7 @@ func (s *Storage) UpdateOrganization(organization *models.Organization) (*models
 	}
 
 	if s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return updatedOrganization, nil
@@ -383,7 +383,7 @@ func (s *Storage) RemoveOrganization(id string) error {
 	})
 
 	if err == nil && s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return err

--- a/storage/auth/rules.go
+++ b/storage/auth/rules.go
@@ -140,7 +140,7 @@ func (s *Storage) addRule(rule *models.Rule) (*models.Rule, error) {
 
 	// refresh policy
 	if err == nil && s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return rule, err
@@ -171,7 +171,7 @@ func (s *Storage) UpdateRule(rule *models.Rule) (*models.Rule, error) {
 
 	// refresh policy
 	if err == nil && s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return rule, err
@@ -214,7 +214,7 @@ func (s *Storage) RemoveRule(id string) error {
 	})
 
 	if err == nil && s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return err

--- a/storage/auth/userRoles.go
+++ b/storage/auth/userRoles.go
@@ -504,7 +504,7 @@ func (s *Storage) addUserRole(userRole *models.UserRole) (*models.UserRole, erro
 	}
 
 	if s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return addedUserRole, err
@@ -600,7 +600,7 @@ func (s *Storage) RemoveUserRole(id string) error {
 	})
 
 	if err == nil && s.refreshRules {
-		go s.enforcer.LoadPolicy()
+		go s.loadPolicy()
 	}
 
 	return err


### PR DESCRIPTION
- To prevent concurrent map writes in casbin that cause
  auth to fail in certain conditions use mutex and wrapper method
  to prevent it.