### PR TITLE
FIX vital sings / medical data display and save

### DIFF
--- a/frontend/local/src/containers/patients/detail/index.js
+++ b/frontend/local/src/containers/patients/detail/index.js
@@ -76,14 +76,14 @@ class PatientDetail extends React.Component {
                                 waitlistItem.vitalSigns.height && (
                                     <div className="col-sm-4">
                                         <h5>Height</h5>
-                                        {waitlistItem.vitalSigns.height}cm
+                                        {waitlistItem.vitalSigns.height.value} cm
                                     </div>
                                 )}
                             {waitlistItem.vitalSigns &&
                                 waitlistItem.vitalSigns.weight && (
                                     <div className="col-sm-4">
                                         <h5>Weight</h5>
-                                        {waitlistItem.vitalSigns.weight}kg
+                                        {waitlistItem.vitalSigns.weight.value} kg
                                     </div>
                                 )}
                             {waitlistItem.vitalSigns &&
@@ -91,7 +91,7 @@ class PatientDetail extends React.Component {
                                 waitlistItem.vitalSigns.weight && (
                                     <div className="col-sm-4">
                                         <h5>BMI</h5>
-                                        {round(waitlistItem.vitalSigns.weight / waitlistItem.vitalSigns.height / waitlistItem.vitalSigns.height * 10000, 2)}
+                                        {round(waitlistItem.vitalSigns.weight.value / waitlistItem.vitalSigns.height.value / waitlistItem.vitalSigns.height.value * 10000, 2)}
                                     </div>
                                 )}
                         </div>

--- a/frontend/local/src/containers/waitlist/detail/index.js
+++ b/frontend/local/src/containers/waitlist/detail/index.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { connect } from "react-redux"
 import { Route, Link } from "react-router-dom"
+import moment from "moment"
 
 import "./style.css"
 
@@ -83,7 +84,7 @@ class InConsultation extends React.Component {
         this.closeConsultation = this.closeConsultation.bind(this)
         this.state = {saving: false}
     }
-x
+
     closeConsultation(ev) {
         ev.preventDefault()
         this.setState({saving: true})
@@ -194,12 +195,12 @@ x
                                             <div className="card-body">
                                                 <div className="card-text">
                                                     <p>
-                                                        <span className="big">{waitlistItem.vitalSigns.height}</span>cm
+                                                        <span className="big">{waitlistItem.vitalSigns.height.value}</span>cm
                                                     </p>
                                                     {/* <p>5ft 1in</p> */}
                                                 </div>
                                             </div>
-                                            {/* <div className="card-footer">5 feb 2018</div> */}
+                                            <div className="card-footer">{moment(waitlistItem.vitalSigns.height.timestamp, "X").format("Do MMM Y")}</div>
                                         </div>
                                     </div>
                                 )}
@@ -212,12 +213,12 @@ x
                                             <div className="card-body">
                                                 <div className="card-text">
                                                     <p>
-                                                        <span className="big">{waitlistItem.vitalSigns.weight}</span>kg
+                                                        <span className="big">{waitlistItem.vitalSigns.weight.value}</span>kg
                                                     </p>
                                                     {/* <p>1008.8 lb</p> */}
                                                 </div>
                                             </div>
-                                            {/* <div className="card-footer">5 feb 2018</div> */}
+                                            <div className="card-footer">{moment(waitlistItem.vitalSigns.weight.timestamp, "X").format("Do MMM Y")}</div>
                                         </div>
                                     </div>
                                 )}
@@ -233,9 +234,9 @@ x
                                                     <p>
                                                         <span className="big">
                                                             {round(
-                                                                waitlistItem.vitalSigns.weight /
-                                                                    waitlistItem.vitalSigns.height /
-                                                                    waitlistItem.vitalSigns.height *
+                                                                waitlistItem.vitalSigns.weight.value /
+                                                                    waitlistItem.vitalSigns.height.value /
+                                                                    waitlistItem.vitalSigns.height.value *
                                                                     10000,
                                                                 2
                                                             )}
@@ -243,7 +244,78 @@ x
                                                     </p>
                                                 </div>
                                             </div>
-                                            {/* <div className="card-footer">5 feb 2018</div> */}
+                                            <div className="card-footer">{moment(waitlistItem.vitalSigns.height.timestamp, "X").isAfter(moment(waitlistItem.vitalSigns.weight.timestamp, "X")) ? moment(waitlistItem.vitalSigns.height.timestamp, "X").format("Do MMM Y") : moment(waitlistItem.vitalSigns.weight.timestamp, "X").format("Do MMM Y") }</div>
+                                        </div>
+                                    </div>
+                                )}
+
+                            {waitlistItem.vitalSigns &&
+                                waitlistItem.vitalSigns.temperature &&
+                                (
+                                    <div className="col-md-5 col-lg-4 col-xl-3">
+                                        <div className="card">
+                                            <div className="card-header">Body temperature</div>
+                                            <div className="card-body">
+                                                <div className="card-text">
+                                                    <p>
+                                                        <span className="big">{waitlistItem.vitalSigns.temperature.value}</span>°C
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div className="card-footer">{moment(waitlistItem.vitalSigns.temperature.timestamp, "X").format("Do MMM Y")}</div>
+                                        </div>
+                                    </div>
+                                )}
+                            {waitlistItem.vitalSigns &&
+                                waitlistItem.vitalSigns.heart_rate &&
+                                (
+                                    <div className="col-md-5 col-lg-4 col-xl-3">
+                                        <div className="card">
+                                            <div className="card-header">Heart rate</div>
+                                            <div className="card-body">
+                                                <div className="card-text">
+                                                    <p>
+                                                        <span className="big">{waitlistItem.vitalSigns.heart_rate.value}</span>bpm
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div className="card-footer">{moment(waitlistItem.vitalSigns.heart_rate.timestamp, "X").format("Do MMM Y")}</div>
+                                        </div>
+                                    </div>
+                                )}
+                            {waitlistItem.vitalSigns &&
+                                waitlistItem.vitalSigns.pressure &&
+                                waitlistItem.vitalSigns.pressure.value.systolic &&
+                                waitlistItem.vitalSigns.pressure.value.diastolic &&
+                                (
+                                    <div className="col-md-5 col-lg-4 col-xl-3">
+                                        <div className="card">
+                                            <div className="card-header">Blood pressure</div>
+                                            <div className="card-body">
+                                                <div className="card-text">
+                                                    <p>
+                                                        <span className="big">{waitlistItem.vitalSigns.pressure.value.systolic}/{waitlistItem.vitalSigns.pressure.value.diastolic}</span>mmHg
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div className="card-footer">{moment(waitlistItem.vitalSigns.pressure.timestamp, "X").format("Do MMM Y")}</div>
+                                        </div>
+                                    </div>
+                                )}
+                            {waitlistItem.vitalSigns &&
+                                waitlistItem.vitalSigns.oxygen_saturation &&
+                                (
+                                    <div className="col-md-5 col-lg-4 col-xl-3">
+                                        <div className="card">
+                                            <div className="card-header">Oxygen saturation</div>
+                                            <div className="card-body">
+                                                <div className="card-text">
+                                                    <p>
+                                                        <span className="big">{waitlistItem.vitalSigns.oxygen_saturation.value}</span>%
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div className="card-footer">{moment(waitlistItem.vitalSigns.oxygen_saturation.timestamp, "X").format("Do MMM Y")}</div>
                                         </div>
                                     </div>
                                 )}

--- a/frontend/local/src/modules/ehr/encounter.js
+++ b/frontend/local/src/modules/ehr/encounter.js
@@ -77,7 +77,7 @@ export default dispatch =>
             ehrPath:
                 "/content[openEHR-EHR-COMPOSITION.encounter.v1]/context/other_context/items[openEHR-EHR-OBSERVATION.body_weight.v2]/data[at0002]/event[at0003]/items[at0001]",
             unit: "kg",
-            formPath: "vitalSigns.weight"
+            formPath: "vitalSigns.weight.value"
         },
 
         // height
@@ -86,7 +86,7 @@ export default dispatch =>
             ehrPath:
                 "/content[openEHR-EHR-COMPOSITION.encounter.v1]/context/other_context/items[openEHR-EHR-OBSERVATION.height.v2]/data[at0001]/events[at0002]/data[at0003]/items[at0004]",
             unit: "cm",
-            formPath: "vitalSigns.height"
+            formPath: "vitalSigns.height.value"
         },
 
         // bmi
@@ -95,7 +95,7 @@ export default dispatch =>
             ehrPath:
                 "/content[openEHR-EHR-COMPOSITION.encounter.v1]/context/other_context/items[openEHR-EHR-OBSERVATION.body_mass_index.v2]/data[at0001]/events[at0002]/data[at0003]/items[at0004]",
             unit: "kg/m2",
-            formPath: "vitalSigns.bmi"
+            formPath: "vitalSigns.bmi.value"
         },
 
         // temperature
@@ -104,7 +104,7 @@ export default dispatch =>
             ehrPath:
                 "/content[openEHR-EHR-COMPOSITION.encounter.v1]/context/other_context/items[openEHR-EHR-OBSERVATION.body_temperature.v2]/data[at0002]/events[at0003]/data[at0001]/items[at0004]",
             unit: "Cel",
-            formPath: "vitalSigns.temperature"
+            formPath: "vitalSigns.temperature.value"
         },
 
         // blood pressure
@@ -114,7 +114,7 @@ export default dispatch =>
             ehrPath:
                 "/content[openEHR-EHR-COMPOSITION.encounter.v1]/context/other_context/items[openEHR-EHR-OBSERVATION.blood_pressure.v1]/data[at0001]/events[at0006]/data[at0003]/items[at0004]",
             unit: "mm[Hg]",
-            formPath: "vitalSigns.bloodPressure.systolic"
+            formPath: "vitalSigns.pressure.value.systolic"
         },
         // diastolic
         {
@@ -122,7 +122,7 @@ export default dispatch =>
             ehrPath:
                 "/content[openEHR-EHR-COMPOSITION.encounter.v1]/context/other_context/items[openEHR-EHR-OBSERVATION.blood_pressure.v1]/data[at0001]/events[at0006]/data[at0003]/items[at0005]",
             unit: "mm[Hg]",
-            formPath: "vitalSigns.bloodPressure.diastolic"
+            formPath: "vitalSigns.pressure.value.diastolic"
         },
 
         // pulse
@@ -137,7 +137,7 @@ export default dispatch =>
             ehrPath:
                 "/content[openEHR-EHR-COMPOSITION.encounter.v1]/context/other_context/items[openEHR-EHR-OBSERVATION.pulse.v1]/data[at0002]/events[at0003]/data[at0001]/items[at0004]",
             unit: "/min",
-            formPath: "vitalSigns.pulse"
+            formPath: "vitalSigns.heart_rate.value"
         },
 
         // oxygen saturation (0 - 100)
@@ -145,6 +145,6 @@ export default dispatch =>
             type: "value",
             ehrPath:
                 "/content[openEHR-EHR-COMPOSITION.encounter.v1]/context/other_context/items[openEHR-EHR-OBSERVATION.pulse_oximetry.v1]/data[at0001]/events[at0002]/data[at0003]/items[at0006]",
-            formPath: "vitalSigns.oxygenSaturation"
+            formPath: "vitalSigns.oxygen_saturation.value"
         }
     ])


### PR DESCRIPTION
- FIX Display all collected medical data in consultation view.
- ADD timestamp of the data; right now it's a bit meaningless
  but timestamp was included in design and potentially old
  data can be loaded to consultation view if not collected
  during encounter.
- FIX saving blood pressure, oxygen saturation and heart rate.
  Previously wrong form paths were set.
- Closes: #87