### PR TITLE
Issue120/minor cloud dashboard fixes

### DIFF
--- a/docs/api/auth.yml
+++ b/docs/api/auth.yml
@@ -1809,6 +1809,12 @@ definitions:
       residency:
         type: string
         description: Country name.
+      phoneNumber:
+        type: string
+        description: Phone number.
+      whatsApp:
+        type: string
+        description: Phone number user for WhatsApp.
       passport:
         type: object
         properties:

--- a/frontend/cloud/src/containers/clinics/list.js
+++ b/frontend/cloud/src/containers/clinics/list.js
@@ -168,7 +168,7 @@ class Clinics extends React.Component {
                                     <td>
                                         {props.canEdit && clinic.edit ? (
                                             <input
-                                                value={clinic.name}
+                                                value={clinic.name || ""}
                                                 onChange={this.editClinicName(i)}
                                                 type="text"
                                                 className="form-control form-control-sm"
@@ -181,7 +181,7 @@ class Clinics extends React.Component {
                                     </td>
                                     <td>
                                         {props.canEdit && clinic.edit ? (
-                                            <select className="form-control form-control-sm" value={clinic.organization} onChange={this.editOrganizationID(i)}>
+                                            <select className="form-control form-control-sm" value={clinic.organization || ""} onChange={this.editOrganizationID(i)}>
                                                 <option value="">Select organization</option>
                                                 {_.map(props.organizations, organization => (
                                                     <option key={organization.id} value={organization.id}>
@@ -195,7 +195,7 @@ class Clinics extends React.Component {
                                     </td>
                                     <td>
                                         {props.canEdit && clinic.edit ? (
-                                            <select className="form-control form-control-sm" value={clinic.location} onChange={this.editLocationID(i)}>
+                                            <select className="form-control form-control-sm" value={clinic.location || ""} onChange={this.editLocationID(i)}>
                                                 <option value="">Select location</option>
                                                 {_.map(props.locations, location => (
                                                     <option key={location.id} value={location.id}>

--- a/frontend/cloud/src/containers/clinics/userDetail.js
+++ b/frontend/cloud/src/containers/clinics/userDetail.js
@@ -132,7 +132,7 @@ class UserDetail extends React.Component {
                                 <th scope="row">{i + 1}</th>
                                 <td>
                                     {props.canEdit && userRole.edit ? (
-                                        <select className="form-control form-control-sm" value={userRole.roleID} onChange={this.editRoleID(i)}>
+                                        <select className="form-control form-control-sm" value={userRole.roleID || ""} onChange={this.editRoleID(i)}>
                                             <option value="">Select role</option>
                                             {_.map(
                                                 _.difference(

--- a/frontend/cloud/src/containers/clinics/usersList.js
+++ b/frontend/cloud/src/containers/clinics/usersList.js
@@ -167,17 +167,17 @@ class UsersList extends React.Component {
                                         <tr key={i}>
                                             <th scope="row">{i + 1}</th>
                                             <td colSpan="3">
-                                                <select className="form-control form-control-sm" value={user.userID} onChange={this.editUserID(i)}>
+                                                <select className="form-control form-control-sm" value={user.userID || ""} onChange={this.editUserID(i)}>
                                                     <option>Select user</option>
                                                     {_.map(_.difference(props.allowedClinicUserIDs, props.clinicUserIDs), userID => (
-                                                        <option key={userID} value={userID}>
+                                                        <option key={userID} value={userID || ""}>
                                                             {props.users[userID].username} - {getName(props.users[userID])} ({props.users[userID].email})
                                                         </option>
                                                     ))}
                                                 </select>
                                             </td>
                                             <td>
-                                                <select className="form-control form-control-sm" value={user.roleID} onChange={this.editRoleID(i)}>
+                                                <select className="form-control form-control-sm" value={user.roleID || ""} onChange={this.editRoleID(i)}>
                                                     <option>Select role</option>
                                                     {_.map(_.pickBy(props.roles, role => !_.includes(props.advancedRoleIDs, role.id)), role => (
                                                         <option key={role.id} value={role.id}>

--- a/frontend/cloud/src/containers/locations/detail.js
+++ b/frontend/cloud/src/containers/locations/detail.js
@@ -148,7 +148,7 @@ class LocationDetail extends React.Component {
                             type="text"
                             className={"form-control" + (this.state.validationErrors["name"] ? " is-invalid" : "")}
                             id="name"
-                            value={this.state.name}
+                            value={this.state.name || ""}
                             onChange={this.updateInput}
                             onBlur={this.onBlurInput}
                             disabled={!props.canEdit}
@@ -167,7 +167,7 @@ class LocationDetail extends React.Component {
                             type="text"
                             className="form-control"
                             id="capacity"
-                            value={this.state.capacity}
+                            value={this.state.capacity || ""}
                             onChange={this.updateCapacity}
                             onBlur={this.onBlurInput}
                             disabled={!props.canEdit}
@@ -179,7 +179,7 @@ class LocationDetail extends React.Component {
                         <select
                             className="form-control form-control-sm"
                             id="country"
-                            value={this.state.country}
+                            value={this.state.country || ""}
                             onChange={this.updateInput}
                             onBlur={this.onBlurInput}
                             disabled={!props.canEdit}
@@ -198,7 +198,7 @@ class LocationDetail extends React.Component {
                             type="text"
                             className="form-control"
                             id="city"
-                            value={this.state.city}
+                            value={this.state.city || ""}
                             onChange={this.updateInput}
                             onBlur={this.onBlurInput}
                             disabled={!props.canEdit}
@@ -237,7 +237,7 @@ class LocationDetail extends React.Component {
                                 type="text"
                                 className="form-control"
                                 id="manager.name"
-                                value={this.state.manager.name}
+                                value={this.state.manager.name || ""}
                                 onChange={this.updateInput}
                                 onBlur={this.onBlurInput}
                                 disabled={!props.canEdit}
@@ -250,7 +250,7 @@ class LocationDetail extends React.Component {
                                 type="email"
                                 className="form-control"
                                 id="manager.email"
-                                value={this.state.manager.email}
+                                value={this.state.manager.email || ""}
                                 onChange={this.updateInput}
                                 onBlur={this.onBlurInput}
                                 disabled={!props.canEdit}
@@ -263,7 +263,7 @@ class LocationDetail extends React.Component {
                                 type="tel"
                                 className="form-control"
                                 id="manager.phoneNumber"
-                                value={this.state.manager.phoneNumber}
+                                value={this.state.manager.phoneNumber || ""}
                                 onChange={this.updateInput}
                                 onBlur={this.onBlurInput}
                                 disabled={!props.canEdit}

--- a/frontend/cloud/src/containers/organizations/clinicsList.js
+++ b/frontend/cloud/src/containers/organizations/clinicsList.js
@@ -153,7 +153,7 @@ class ClinicsList extends React.Component {
                                                 clinic.edit ? (
                                                     <input
                                                         type="text"
-                                                        value={clinic.name}
+                                                        value={clinic.name || ""}
                                                         onChange={this.editClinicName(i)}
                                                         className="form-control form-control-sm"
                                                         placeholder="Clinic name"
@@ -168,10 +168,10 @@ class ClinicsList extends React.Component {
                                         </td>
                                         <td>
                                             {props.canEdit && clinic.edit ? (
-                                                <select className="form-control form-control-sm" value={clinic.location} onChange={this.editLocationID(i)}>
+                                                <select className="form-control form-control-sm" value={clinic.location || ""} onChange={this.editLocationID(i)}>
                                                     <option value="">Select location</option>
                                                     {_.map(props.locations, location => (
-                                                        <option key={location.id} value={location.id}>
+                                                        <option key={location.id} value={location.id || ""}>
                                                             {location.name}
                                                         </option>
                                                     ))}

--- a/frontend/cloud/src/containers/organizations/detail.js
+++ b/frontend/cloud/src/containers/organizations/detail.js
@@ -147,7 +147,7 @@ class OrganizationDetail extends React.Component {
                                 type="text"
                                 className={"form-control" + (this.state.validationErrors["name"] ? " is-invalid" : "")}
                                 id="name"
-                                value={this.state.name}
+                                value={this.state.name || ""}
                                 onChange={this.updateInput}
                                 onBlur={this.onBlurInput}
                                 disabled={!props.canEdit}
@@ -166,7 +166,7 @@ class OrganizationDetail extends React.Component {
                                 type="text"
                                 className="form-control"
                                 id="legalStatus"
-                                value={this.state.legalStatus}
+                                value={this.state.legalStatus || ""}
                                 onChange={this.updateInput}
                                 onBlur={this.onBlurInput}
                                 disabled={!props.canEdit}
@@ -179,7 +179,7 @@ class OrganizationDetail extends React.Component {
                                 type="text"
                                 className="form-control"
                                 id="serviceType"
-                                value={this.state.serviceType}
+                                value={this.state.serviceType || ""}
                                 onChange={this.updateInput}
                                 onBlur={this.onBlurInput}
                                 disabled={!props.canEdit}
@@ -194,7 +194,7 @@ class OrganizationDetail extends React.Component {
                                     type="text"
                                     className="form-control"
                                     id="address.addressLine1"
-                                    value={this.state.address.addressLine1}
+                                    value={this.state.address.addressLine1 || ""}
                                     onChange={this.updateInput}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}
@@ -207,7 +207,7 @@ class OrganizationDetail extends React.Component {
                                     type="text"
                                     className="form-control"
                                     id="address.addressLine2"
-                                    value={this.state.address.addressLine2}
+                                    value={this.state.address.addressLine2 || ""}
                                     onChange={this.updateInput}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}
@@ -233,7 +233,7 @@ class OrganizationDetail extends React.Component {
                                     type="tel"
                                     className="form-control"
                                     id="address.postCode"
-                                    value={this.state.address.postCode}
+                                    value={this.state.address.postCode || ""}
                                     onChange={this.updateInput}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}
@@ -245,7 +245,7 @@ class OrganizationDetail extends React.Component {
                                 <select
                                     className="form-control form-control-sm"
                                     id="address.country"
-                                    value={this.state.address.country}
+                                    value={this.state.address.country || ""}
                                     onChange={this.updatePersonalData}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}
@@ -267,7 +267,7 @@ class OrganizationDetail extends React.Component {
                                     type="text"
                                     className="form-control"
                                     id="representative.name"
-                                    value={this.state.representative.name}
+                                    value={this.state.representative.name || ""}
                                     onChange={this.updateInput}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}
@@ -280,7 +280,7 @@ class OrganizationDetail extends React.Component {
                                     type="email"
                                     className="form-control"
                                     id="representative.email"
-                                    value={this.state.representative.email}
+                                    value={this.state.representative.email || ""}
                                     onChange={this.updateInput}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}
@@ -293,7 +293,7 @@ class OrganizationDetail extends React.Component {
                                     type="tel"
                                     className="form-control"
                                     id="representative.phoneNumber"
-                                    value={this.state.representative.phoneNumber}
+                                    value={this.state.representative.phoneNumber || ""}
                                     onChange={this.updateInput}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}
@@ -309,7 +309,7 @@ class OrganizationDetail extends React.Component {
                                     type="text"
                                     className="form-control"
                                     id="primaryContact.name"
-                                    value={this.state.primaryContact.name}
+                                    value={this.state.primaryContact.name || ""}
                                     onChange={this.updateInput}
                                     disabled={!props.canEdit}
                                     placeholder="Full name"
@@ -321,7 +321,7 @@ class OrganizationDetail extends React.Component {
                                     type="email"
                                     className="form-control"
                                     id="primaryContact.email"
-                                    value={this.state.primaryContact.email}
+                                    value={this.state.primaryContact.email || ""}
                                     onChange={this.updateInput}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}
@@ -334,7 +334,7 @@ class OrganizationDetail extends React.Component {
                                     type="tel"
                                     className="form-control"
                                     id="primaryContact.phoneNumber"
-                                    value={this.state.primaryContact.phoneNumber}
+                                    value={this.state.primaryContact.phoneNumber || ""}
                                     onChange={this.updateInput}
                                     onBlur={this.onBlurInput}
                                     disabled={!props.canEdit}

--- a/frontend/cloud/src/containers/organizations/userDetail.js
+++ b/frontend/cloud/src/containers/organizations/userDetail.js
@@ -129,7 +129,7 @@ class UserDetail extends React.Component {
                                 <th scope="row">{i + 1}</th>
                                 <td>
                                     {props.canEdit && userRole.edit ? (
-                                        <select className="form-control form-control-sm" value={userRole.roleID} onChange={this.editRoleID(i)}>
+                                        <select className="form-control form-control-sm" value={userRole.roleID || ""} onChange={this.editRoleID(i)}>
                                             <option value="">Select role</option>
                                             {_.map(
                                                 _.difference(

--- a/frontend/cloud/src/containers/organizations/usersList.js
+++ b/frontend/cloud/src/containers/organizations/usersList.js
@@ -159,7 +159,7 @@ class UsersList extends React.Component {
                                         <tr key={i}>
                                             <th scope="row">{i + 1}</th>
                                             <td colSpan="2">
-                                                <select className="form-control form-control-sm" value={user.userID} onChange={this.editUserID(i)}>
+                                                <select className="form-control form-control-sm" value={user.userID || ""} onChange={this.editUserID(i)}>
                                                     <option>Select user</option>
                                                     {_.map(_.difference(_.map(_.values(props.users), user => user.id), props.organizationUserIDs), userID => (
                                                         <option key={userID} value={userID}>
@@ -169,7 +169,7 @@ class UsersList extends React.Component {
                                                 </select>
                                             </td>
                                             <td colSpan="2">
-                                                <select className="form-control form-control-sm" value={user.roleID} onChange={this.editRoleID(i)}>
+                                                <select className="form-control form-control-sm" value={user.roleID || ""} onChange={this.editRoleID(i)}>
                                                     <option>Select role</option>
                                                     {_.map(_.pickBy(props.roles, role => !_.includes(props.advancedRoleIDs, role.id)), role => (
                                                         <option key={role.id} value={role.id}>

--- a/frontend/cloud/src/containers/roles/index.js
+++ b/frontend/cloud/src/containers/roles/index.js
@@ -121,7 +121,7 @@ class Roles extends React.Component {
                             <div className="input-group mb-3">
                                 <input
                                     type="text"
-                                    value={this.state.roleName}
+                                    value={this.state.roleName || ""}
                                     onChange={this.updateRoleName()}
                                     className="form-control form-control-sm"
                                     placeholder="Role name"

--- a/frontend/cloud/src/containers/rules/index.js
+++ b/frontend/cloud/src/containers/rules/index.js
@@ -222,7 +222,7 @@ class Rules extends React.Component {
                                       {!props.embedded ? (
                                           <td>
                                               {props.canEdit && rule.edit ? (
-                                                  <select className="form-control form-control-sm" value={rule.subject} onChange={this.editSubject(i)}>
+                                                  <select className="form-control form-control-sm" value={rule.subject || ""} onChange={this.editSubject(i)}>
                                                       <option>Select subject</option>
                                                       <optgroup label="Roles">
                                                           {_.map(props.roles, role => (
@@ -251,7 +251,7 @@ class Rules extends React.Component {
                                               <input
                                                   type="text"
                                                   className="form-control form-control-sm"
-                                                  value={rule.resource}
+                                                  value={rule.resource || ""}
                                                   onChange={this.editResource(i)}
                                               />
                                           ) : (

--- a/frontend/cloud/src/containers/userRoles/list.js
+++ b/frontend/cloud/src/containers/userRoles/list.js
@@ -204,7 +204,7 @@ class UserRoles extends React.Component {
         switch (domainType) {
             case "organization":
                 return (
-                    <select className="form-control form-control-sm" value={domainID} onChange={this.editDomainID(index)}>
+                    <select className="form-control form-control-sm" value={domainID || ""} onChange={this.editDomainID(index)}>
                         <option>Select organization</option>
                         {_.map(this.props.organizations, organization => (
                             <option key={organization.id} value={organization.id}>
@@ -216,7 +216,7 @@ class UserRoles extends React.Component {
                 )
             case "clinic":
                 return (
-                    <select className="form-control form-control-sm" value={domainID} onChange={this.editDomainID(index)}>
+                    <select className="form-control form-control-sm" value={domainID || ""} onChange={this.editDomainID(index)}>
                         <option>Select clinic</option>
                         {_.map(this.props.clinics, clinic => (
                             <option key={clinic.id} value={clinic.id}>
@@ -228,7 +228,7 @@ class UserRoles extends React.Component {
                 )
             case "location":
                 return (
-                    <select className="form-control form-control-sm" value={domainID} onChange={this.editDomainID(index)}>
+                    <select className="form-control form-control-sm" value={domainID || ""} onChange={this.editDomainID(index)}>
                         <option>Select location</option>
                         {_.map(this.props.locations, location => (
                             <option key={location.id} value={location.id}>
@@ -240,7 +240,7 @@ class UserRoles extends React.Component {
                 )
             case "user":
                 return (
-                    <select className="form-control form-control-sm" value={domainID} onChange={this.editDomainID(index)}>
+                    <select className="form-control form-control-sm" value={domainID || ""} onChange={this.editDomainID(index)}>
                         <option>Select user</option>
                         {_.map(this.props.users, user => (
                             <option key={user.id} value={user.id}>
@@ -253,7 +253,7 @@ class UserRoles extends React.Component {
             case "cloud":
             case "global":
                 return (
-                    <select className="form-control form-control-sm" value={domainID} onChange={this.editDomainID(index)}>
+                    <select className="form-control form-control-sm" value={domainID || ""} onChange={this.editDomainID(index)}>
                         <option key="*" value="*">
                             *
                         </option>
@@ -261,7 +261,7 @@ class UserRoles extends React.Component {
                 )
             default:
                 return (
-                    <select className="form-control form-control-sm" value={domainID} disabled={true}>
+                    <select className="form-control form-control-sm" value={domainID || ""} disabled={true}>
                         <option>Select domain type first</option>
                     </select>
                 )
@@ -296,7 +296,7 @@ class UserRoles extends React.Component {
                                 <th scope="row">{i + 1}</th>
                                 <td>
                                     {props.canEdit && userRole.edit ? (
-                                        <select className="form-control form-control-sm" value={userRole.userID} onChange={this.editUserID(i)}>
+                                        <select className="form-control form-control-sm" value={userRole.userID || ""} onChange={this.editUserID(i)}>
                                             <option>Select user</option>
                                             {_.map(props.users, user => (
                                                 <option key={user.id} value={user.id}>
@@ -312,7 +312,7 @@ class UserRoles extends React.Component {
                                 </td>
                                 <td>
                                     {props.canEdit && userRole.edit ? (
-                                        <select className="form-control form-control-sm" value={userRole.roleID} onChange={this.editRoleID(i)}>
+                                        <select className="form-control form-control-sm" value={userRole.roleID || ""} onChange={this.editRoleID(i)}>
                                             <option>Select role</option>
                                             {_.map(props.roles, role => (
                                                 <option key={role.id} value={role.id}>
@@ -326,7 +326,7 @@ class UserRoles extends React.Component {
                                 </td>
                                 <td>
                                     {props.canEdit && userRole.edit ? (
-                                        <select className="form-control form-control-sm" value={userRole.domainType} onChange={this.editDomainType(i)}>
+                                        <select className="form-control form-control-sm" value={userRole.domainType || ""} onChange={this.editDomainType(i)}>
                                             <option>Select domain type</option>
                                             <option key="global" value="global">
                                                 global

--- a/frontend/cloud/src/containers/users/clinicDetail.js
+++ b/frontend/cloud/src/containers/users/clinicDetail.js
@@ -123,7 +123,7 @@ class ClinicDetail extends React.Component {
                                 <th scope="row">{i + 1}</th>
                                 <td>
                                     {props.canEdit && userRole.edit ? (
-                                        <select className="form-control form-control-sm" value={userRole.roleID} onChange={this.editRoleID(i)}>
+                                        <select className="form-control form-control-sm" value={userRole.roleID || ""} onChange={this.editRoleID(i)}>
                                             <option value="">Select role</option>
                                             {_.map(
                                                 _.difference(

--- a/frontend/cloud/src/containers/users/clinicsList.js
+++ b/frontend/cloud/src/containers/users/clinicsList.js
@@ -181,7 +181,7 @@ class ClinicsList extends React.Component {
                                             <tr key={userClinic.id || i} className={this.state.selectedClinicID === userClinic.id ? "table-active" : ""}>
                                                 <th scope="row">{i + 1}</th>
                                                 <td colSpan="2">
-                                                    <select className="form-control form-control-sm" value={userClinic.id} onChange={this.editClinicID(i)}>
+                                                    <select className="form-control form-control-sm" value={userClinic.id || ""} onChange={this.editClinicID(i)}>
                                                         <option value="">Select clinic</option>
                                                         {_.map(
                                                             _.difference(
@@ -198,7 +198,7 @@ class ClinicsList extends React.Component {
                                                     </select>
                                                 </td>
                                                 <td>
-                                                    <select className="form-control form-control-sm" value={userClinic.roleID} onChange={this.editRoleID(i)}>
+                                                    <select className="form-control form-control-sm" value={userClinic.roleID || ""} onChange={this.editRoleID(i)}>
                                                         <option value="">Select role</option>
                                                         {_.map(_.pickBy(props.roles, role => !_.includes(props.advancedRoleIDs, role.id)), role => (
                                                             <option key={role.id} value={role.id}>

--- a/frontend/cloud/src/containers/users/detail.js
+++ b/frontend/cloud/src/containers/users/detail.js
@@ -530,7 +530,7 @@ class UserDetail extends React.Component {
                                 ) : null}
                             </div>
                             <div className="form-group">
-                                <label htmlFor="nationality">Nationality</label>
+                                <label htmlFor="personalData.nationality">Nationality</label>
                                 <select
                                     className="form-control form-control-sm"
                                     id="personalData.nationality"
@@ -547,7 +547,7 @@ class UserDetail extends React.Component {
                                 </select>
                             </div>
                             <div className="form-group">
-                                <label htmlFor="residency">Residency</label>
+                                <label htmlFor="personalData.residency">Residency</label>
                                 <select
                                     className="form-control form-control-sm"
                                     id="personalData.residency"
@@ -562,6 +562,32 @@ class UserDetail extends React.Component {
                                         </option>
                                     ))}
                                 </select>
+                            </div>
+                            <div className="form-group">
+                                <label htmlFor="personalData.phoneNumber">Phone number</label>
+                                <input
+                                    type="tel"
+                                    className="form-control"
+                                    id="personalData.phoneNumber"
+                                    value={this.state.personalData.phoneNumber || ""}
+                                    onChange={this.updateInput}
+                                    onBlur={this.onBlurInput}
+                                    disabled={!props.canEdit}
+                                    placeholder="+38640..."
+                                />
+                            </div>
+                            <div className="form-group">
+                                <label htmlFor="personalData.whatsApp">WhatsApp</label>
+                                <input
+                                    type="tel"
+                                    className="form-control"
+                                    id="personalData.whatsApp"
+                                    value={this.state.personalData.whatsApp || ""}
+                                    onChange={this.updateInput}
+                                    onBlur={this.onBlurInput}
+                                    disabled={!props.canEdit}
+                                    placeholder="+38640..."
+                                />
                             </div>
                             <div className="form_group">
                                 <h4>Passport</h4>

--- a/frontend/cloud/src/containers/users/organizationDetail.js
+++ b/frontend/cloud/src/containers/users/organizationDetail.js
@@ -129,7 +129,7 @@ class OrganizationDetail extends React.Component {
                                 <th scope="row">{i + 1}</th>
                                 <td>
                                     {props.canEdit && userRole.edit ? (
-                                        <select className="form-control form-control-sm" value={userRole.roleID} onChange={this.editRoleID(i)}>
+                                        <select className="form-control form-control-sm" value={userRole.roleID || ""} onChange={this.editRoleID(i)}>
                                             <option value="">Select role</option>
                                             {_.map(
                                                 _.difference(

--- a/frontend/cloud/src/containers/users/organizationsList.js
+++ b/frontend/cloud/src/containers/users/organizationsList.js
@@ -163,7 +163,7 @@ class OrganizationsList extends React.Component {
                                             {props.canEdit && userOrganization.edit ? (
                                                 <select
                                                     className="form-control form-control-sm"
-                                                    value={userOrganization.id}
+                                                    value={userOrganization.id || ""}
                                                     onChange={this.editOrganizationID(i)}
                                                 >
                                                     <option value="">Select organization</option>
@@ -189,7 +189,7 @@ class OrganizationsList extends React.Component {
                                         </td>
                                         <td>
                                             {props.canEdit && userOrganization.edit ? (
-                                                <select className="form-control form-control-sm" value={userOrganization.roleID} onChange={this.editRoleID(i)}>
+                                                <select className="form-control form-control-sm" value={userOrganization.roleID || ""} onChange={this.editRoleID(i)}>
                                                     <option value="">Select role</option>
                                                     {_.map(_.pickBy(props.roles, role => !_.includes(props.advancedRoleIDs, role.id)), role => (
                                                         <option key={role.id} value={role.id}>


### PR DESCRIPTION
- UPD Instead of using custom way of controlling input for date
  use default one.
- FIX React warnings for switching inputs between uncontrolled
  to controlled. When value is set to undefined React treats
  input component as uncontrolled. Set empty string instead of undefined
  for unset values.
- Closes: #120