### PR TITLE
ADD list history items + reopen item to waitlist

### DIFF
--- a/cmd/waitlist/handlers.go
+++ b/cmd/waitlist/handlers.go
@@ -132,3 +132,35 @@ func (h *handlers) ItemPutListIDItemIDTop() item.PutListIDItemIDTopHandler {
 		return item.NewPutListIDItemIDTopNoContent()
 	})
 }
+
+func (h *handlers) ItemGetListIDHistory() item.GetListIDHistoryHandler {
+	return item.GetListIDHistoryHandlerFunc(func(params item.GetListIDHistoryParams, principal *string) middleware.Responder {
+		listID, _ := utils.UUIDToBytes(params.ListID)
+
+		items, err := h.s.ListHistoryItems(listID, params.Reason)
+		if err != nil {
+			return utils.NewErrorResponse(err)
+		}
+
+		return item.NewGetListIDHistoryOK().WithPayload(items)
+	})
+}
+
+func (h *handlers) ItemPutListIDItemIDReopen() item.PutListIDItemIDReopenHandler {
+	return item.PutListIDItemIDReopenHandlerFunc(func(params item.PutListIDItemIDReopenParams, principal *string) middleware.Responder {
+		listID, _ := utils.UUIDToBytes(params.ListID)
+		itemID, _ := utils.UUIDToBytes(params.ItemID)
+
+		var newListID []byte
+		if params.NewListID != nil {
+			newListID, _ = utils.UUIDToBytes(*params.NewListID)
+		}
+
+		_, err := h.s.ReopenHistoryItem(listID, itemID, newListID)
+		if err != nil {
+			return utils.NewErrorResponse(err)
+		}
+
+		return item.NewPutListIDItemIDReopenNoContent()
+	})
+}

--- a/cmd/waitlist/main.go
+++ b/cmd/waitlist/main.go
@@ -96,9 +96,11 @@ func main() {
 
 	api.ItemDeleteListIDItemIDHandler = h.ItemDeleteListIDItemID()
 	api.ItemGetListIDHandler = h.ItemGetListID()
+	api.ItemGetListIDHistoryHandler = h.ItemGetListIDHistory()
 	api.ItemPostListIDHandler = h.ItemPostListID()
 	api.ItemPutListIDItemIDHandler = h.ItemPutListIDItemID()
 	api.ItemPutListIDItemIDTopHandler = h.ItemPutListIDItemIDTop()
+	api.ItemPutListIDItemIDReopenHandler = h.ItemPutListIDItemIDReopen()
 
 	// initialize metrics middleware
 	apiMetrics := APIMetrics.NewMetrics("api", "").WithURLSanitize(utils.WhitelistURLSanitize([]string{}))

--- a/docs/api/waitlist.yml
+++ b/docs/api/waitlist.yml
@@ -225,6 +225,46 @@ paths:
         500:
           $ref: '#/responses/500'
 
+  /{listID}/history:
+    get:
+      tags:
+        - item
+
+      parameters:
+        - in: path
+          name: listID
+          required: true
+          type: string
+          format: uuid
+        - in: query
+          name: reason
+          type: string
+          enum:
+            - finished
+            - canceled
+
+      summary: Waitlist
+      description: Returns all the already closed or removed items from the waitlist, result can be filtered by reason.
+
+      responses:
+        200:
+          description: Waitlist items
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Item'
+
+        401:
+          $ref: '#/responses/401'
+
+        403:
+          $ref: '#/responses/403'
+
+        404:
+          $ref: '#/responses/404'
+
+        500:
+          $ref: '#/responses/500'
 
   /{listID}/{itemID}:
     put:
@@ -328,6 +368,49 @@ paths:
         - in: path
           name: itemID
           required: true
+          type: string
+          format: uuid
+
+      responses:
+        204:
+          description: Item was updated
+
+        400:
+          $ref: '#/responses/400'
+
+        401:
+          $ref: '#/responses/401'
+
+        403:
+          $ref: '#/responses/403'
+
+        404:
+          $ref: '#/responses/404'
+
+        500:
+          $ref: '#/responses/500'
+
+  /{listID}/{itemID}/reopen:
+    put:
+      summary: Reopens waitlist item that was closed or removed, ID of the list to which reopened item should be put can be specified.
+      tags:
+        - item
+
+      parameters:
+        - in: path
+          name: listID
+          required: true
+          type: string
+          format: uuid
+
+        - in: path
+          name: itemID
+          required: true
+          type: string
+          format: uuid
+
+        - in: query
+          name: newListID
           type: string
           format: uuid
 

--- a/storage/waitlist/storage.go
+++ b/storage/waitlist/storage.go
@@ -44,6 +44,12 @@ type Storage interface {
 	// DeleteItem removes an item from a waitlist and moves it to history
 	DeleteItem(waitlistID, itemID []byte, reason string) error
 
+	// ListHistoryItems returns all items in waitlist's history
+	ListHistoryItems(waitlistID []byte, reason *string) ([]*models.Item, error)
+
+	// ReopenHistoryItem puts item from history back to waitlist
+	ReopenHistoryItem(waitlistID, itemID, newWaitlistID []byte) (*models.Item, error)
+
 	// Close closes the database
 	Close() error
 


### PR DESCRIPTION
- Adds two funcionalities to waitlist service:
  - listing all archived items of waitlist,
  - reopening archived item.
- Closes: #124