### PR TITLE
Issue139 / Update patient data in waitlist

### DIFF
--- a/cmd/waitlist/main.go
+++ b/cmd/waitlist/main.go
@@ -98,6 +98,7 @@ func main() {
 	api.ItemPutListIDItemIDHandler = h.UpdateItem()
 	api.ItemPutListIDItemIDTopHandler = h.MoveItemToTop()
 	api.ItemPutListIDItemIDReopenHandler = h.ReopenHistoryItem()
+	api.ItemPutPatientPatientIDHandler = h.UpdatePatient()
 
 	// initialize metrics middleware
 	apiMetrics := APIMetrics.NewMetrics("api", "").WithURLSanitize(utils.WhitelistURLSanitize([]string{}))

--- a/docs/api/waitlist.yml
+++ b/docs/api/waitlist.yml
@@ -436,6 +436,45 @@ paths:
         500:
           $ref: '#/responses/500'
 
+  /patient/{patientID}:
+    put:
+      summary: Updates patient data in all the items with this patient.
+      tags:
+        - item
+
+      parameters:
+        - in: path
+          name: patientID
+          required: true
+          type: string
+          format: uuid
+
+        - in: body
+          name: patient
+          required: true
+          schema:
+            $ref: '#/definitions/Patient'
+
+      responses:
+        204:
+          description: Items were updated
+
+        400:
+          $ref: '#/responses/400'
+
+        401:
+          $ref: '#/responses/401'
+
+        403:
+          $ref: '#/responses/403'
+
+        404:
+          $ref: '#/responses/404'
+
+        500:
+          $ref: '#/responses/500'
+
+
 definitions:
   List:
     type: object

--- a/frontend/local/src/containers/patients/detail/record.js
+++ b/frontend/local/src/containers/patients/detail/record.js
@@ -65,6 +65,16 @@ class HealthRecord extends React.Component {
                                                             <DiagnosisIcon />
                                                             {_.get(data.diagnoses[0], "diagnosis.label", "Diagnosis")}
                                                         </h3>
+
+                                                        <div className="context">
+                                                            <span key="endTime">{moment(_.get(data.context, "endTime")).format("Do MMM YYYY, HH:mm")}</span>
+                                                            <span key="seperator"> · </span>
+                                                            <span key="authorName">
+                                                                {_.get(data.context, "author.name").trim() !== ""
+                                                                    ? _.get(data.context, "author.name").trim()
+                                                                    : "Unknown diagnosis author"}
+                                                            </span>
+                                                        </div>
                                                         <div className="comment">{_.get(data.diagnoses[0], "comment", "")}</div>
                                                     </React.Fragment>
                                                 ) : (

--- a/frontend/local/src/containers/patients/detail/style.scss
+++ b/frontend/local/src/containers/patients/detail/style.scss
@@ -427,6 +427,16 @@
         font-size: 16px;
     }
 
+    .context {
+        opacity: 0.3;
+        font-size: 14px;
+        font-weight: normal;
+        font-style: normal;
+        font-stretch: normal;
+        line-height: 1.79;
+        color: $black;
+    }
+
     .comment {
         margin: 10px 0;
     }

--- a/frontend/local/src/modules/discovery.js
+++ b/frontend/local/src/modules/discovery.js
@@ -2,6 +2,7 @@ import produce from "immer"
 import { open, COLOR_DANGER } from "shared/modules/alert"
 import { read, API_URL, LOCATION_ID } from "shared/modules/config"
 import { getToken } from "shared/modules/authentication"
+import { updatePatient as updateWaitlistPatient } from "./waitlist"
 
 export const SEARCH = "patient/SEARCH"
 export const SEARCHED = "patient/SEARCHED"
@@ -129,6 +130,8 @@ export const updatePatient = (patientID, formData) => dispatch => {
             if (!ok) {
                 throw new Error("Failed to update patient")
             }
+
+            dispatch(updateWaitlistPatient(patientID, data.connections))
 
             dispatch({ type: UPDATED, result: data })
             return data

--- a/frontend/local/src/modules/ehr/context.js
+++ b/frontend/local/src/modules/ehr/context.js
@@ -1,0 +1,48 @@
+export default dispatch =>
+    Promise.resolve([
+        {
+            type: "value",
+            ehrPath: "/context/health_care_facility|name",
+            formPath: "context.clinic.name"
+        },
+        {
+            type: "value",
+            ehrPath: "/context/health_care_facility|identifier",
+            formPath: "context.clinic.id"
+        },
+        {
+            type: "value",
+            ehrPath: "/territory",
+            formPath: "context.territory"
+        },
+        {
+            type: "value",
+            ehrPath: "/language",
+            formPath: "context.language"
+        },
+        {
+            type: "dateTime",
+            ehrPath: "/context/start_time",
+            formPath: "context.startTime"
+        },
+        {
+            type: "dateTime",
+            ehrPath: "/context/start_time",
+            formPath: "context.endTime"
+        },
+        {
+            type: "value",
+            ehrPath: "/composer|identifier",
+            formPath: "context.author.id"
+        },
+        {
+            type: "value",
+            ehrPath: "/composer|name",
+            formPath: "context.author.name"
+        },
+        {
+            type: "value",
+            ehrPath: "/category",
+            formPath: "context.category"
+        }
+    ])

--- a/frontend/local/src/modules/patient.js
+++ b/frontend/local/src/modules/patient.js
@@ -3,7 +3,7 @@ import produce from "immer"
 // insert into storage
 import { open, COLOR_DANGER } from "shared/modules/alert"
 import { newPatient, updatePatient as updateDiscoveryPatient, get, cardToObject } from "./discovery"
-import { extractPatientData, composePatientData, composeEncounterData, extractEncounterData } from "./ehr"
+import { extractPatientData, composePatientData, composeEncounterData, extractEncounterDataWithContext } from "./ehr"
 import { createPatient as createPatientInStorage, readFileByLabel, updateFile, uploadFile, readFilesByLabel } from "./storage"
 import { get as waitlistGet, remove as waitlistRemove } from "./waitlist"
 
@@ -416,7 +416,7 @@ export const fetchHealthRecords = patientID => dispatch => {
     dispatch({ type: FETCH_RECORDS })
 
     return dispatch(readFilesByLabel(patientID, "encounter"))
-        .then(documents => Promise.all(documents.map(document => Promise.all([dispatch(extractEncounterData(document.data)), document.meta]))))
+        .then(documents => Promise.all(documents.map(document => Promise.all([dispatch(extractEncounterDataWithContext(document.data)), document.meta]))))
         .then(documents => documents.map(([data, meta]) => ({ data, meta })))
         .then(documents => {
             dispatch({

--- a/service/waitlist/handlers.go
+++ b/service/waitlist/handlers.go
@@ -11,16 +11,29 @@ import (
 
 // Handlers describes the actions supported by the discovery handlers
 type Handlers interface {
+	// GetWaitlists returns all active lists
 	GetWaitlists() waitlist.GetHandler
+	// CreateWaitlist creates new list
 	CreateWaitlist() waitlist.PostHandler
+	// UpdateWaitlist updates list metadata
 	UpdateWaitlist() waitlist.PutListIDHandler
+	// DeleteWaitlist removes list from active lists and move its items to history
 	DeleteWaitlist() waitlist.DeleteListIDHandler
+	// GetWaitlist returns all items in a waitlist
 	GetWaitlist() item.GetListIDHandler
+	// GetWaitlistHistory returns all items in waitlist's history
 	GetWaitlistHistory() item.GetListIDHistoryHandler
+	// DeleteItem removes an item from a waitlist and moves it to history
 	DeleteItem() item.DeleteListIDItemIDHandler
+	// CreateItem creates a new item in a waitlist
 	CreateItem() item.PostListIDHandler
+	// UpdateItem updates an item in a waitlist
 	UpdateItem() item.PutListIDItemIDHandler
+	// UpdatePatient updates with new patient data all the items with specified patientID
+	UpdatePatient() item.PutPatientPatientIDHandler
+	// UpdatePatient updates with new patient data all the items with specified patientID
 	MoveItemToTop() item.PutListIDItemIDTopHandler
+	// ReopenHistoryItem puts item from history back to waitlist
 	ReopenHistoryItem() item.PutListIDItemIDReopenHandler
 }
 
@@ -29,6 +42,7 @@ type handlers struct {
 	logger zerolog.Logger
 }
 
+// GetWaitlists returns all active lists
 func (h *handlers) GetWaitlists() waitlist.GetHandler {
 	return waitlist.GetHandlerFunc(func(params waitlist.GetParams, principal *string) middleware.Responder {
 		lists, err := h.s.GetWaitlists()
@@ -40,6 +54,7 @@ func (h *handlers) GetWaitlists() waitlist.GetHandler {
 	})
 }
 
+// CreateWaitlist creates new list
 func (h *handlers) CreateWaitlist() waitlist.PostHandler {
 	return waitlist.PostHandlerFunc(func(params waitlist.PostParams, principal *string) middleware.Responder {
 		list, err := h.s.CreateWaitlist(*params.List.Name)
@@ -51,6 +66,7 @@ func (h *handlers) CreateWaitlist() waitlist.PostHandler {
 	})
 }
 
+// UpdateWaitlist updates list metadata
 func (h *handlers) UpdateWaitlist() waitlist.PutListIDHandler {
 	return waitlist.PutListIDHandlerFunc(func(params waitlist.PutListIDParams, principal *string) middleware.Responder {
 		if params.ListID.String() != params.List.ID {
@@ -66,6 +82,7 @@ func (h *handlers) UpdateWaitlist() waitlist.PutListIDHandler {
 	})
 }
 
+// DeleteWaitlist removes list from active lists and move its items to history
 func (h *handlers) DeleteWaitlist() waitlist.DeleteListIDHandler {
 	return waitlist.DeleteListIDHandlerFunc(func(params waitlist.DeleteListIDParams, principal *string) middleware.Responder {
 		listID, _ := utils.UUIDToBytes(params.ListID)
@@ -79,6 +96,7 @@ func (h *handlers) DeleteWaitlist() waitlist.DeleteListIDHandler {
 	})
 }
 
+// GetWaitlist returns all items in a waitlist
 func (h *handlers) GetWaitlist() item.GetListIDHandler {
 	return item.GetListIDHandlerFunc(func(params item.GetListIDParams, principal *string) middleware.Responder {
 		listID, _ := utils.UUIDToBytes(params.ListID)
@@ -92,6 +110,7 @@ func (h *handlers) GetWaitlist() item.GetListIDHandler {
 	})
 }
 
+// DeleteItem removes an item from a waitlist and moves it to history
 func (h *handlers) DeleteItem() item.DeleteListIDItemIDHandler {
 	return item.DeleteListIDItemIDHandlerFunc(func(params item.DeleteListIDItemIDParams, principal *string) middleware.Responder {
 		listID, _ := utils.UUIDToBytes(params.ListID)
@@ -106,6 +125,7 @@ func (h *handlers) DeleteItem() item.DeleteListIDItemIDHandler {
 	})
 }
 
+// CreateItem creates a new item in a waitlist
 func (h *handlers) CreateItem() item.PostListIDHandler {
 	return item.PostListIDHandlerFunc(func(params item.PostListIDParams, principal *string) middleware.Responder {
 		listID, _ := utils.UUIDToBytes(params.ListID)
@@ -119,6 +139,7 @@ func (h *handlers) CreateItem() item.PostListIDHandler {
 	})
 }
 
+// UpdateItem updates an item in a waitlist
 func (h *handlers) UpdateItem() item.PutListIDItemIDHandler {
 	return item.PutListIDItemIDHandlerFunc(func(params item.PutListIDItemIDParams, principal *string) middleware.Responder {
 		if params.ItemID.String() != params.Item.ID {
@@ -135,6 +156,20 @@ func (h *handlers) UpdateItem() item.PutListIDItemIDHandler {
 	})
 }
 
+// UpdatePatient updates with new patient data all the items with specified patientID
+func (h *handlers) UpdatePatient() item.PutPatientPatientIDHandler {
+	return item.PutPatientPatientIDHandlerFunc(func(params item.PutPatientPatientIDParams, principal *string) middleware.Responder {
+		patientID, _ := utils.UUIDToBytes(params.PatientID)
+		_, err := h.s.UpdatePatient(patientID, params.Patient)
+		if err != nil {
+			return utils.NewErrorResponse(err)
+		}
+
+		return item.NewPutPatientPatientIDNoContent()
+	})
+}
+
+// UpdatePatient updates with new patient data all the items with specified patientID
 func (h *handlers) MoveItemToTop() item.PutListIDItemIDTopHandler {
 	return item.PutListIDItemIDTopHandlerFunc(func(params item.PutListIDItemIDTopParams, principal *string) middleware.Responder {
 		listID, _ := utils.UUIDToBytes(params.ListID)
@@ -149,6 +184,7 @@ func (h *handlers) MoveItemToTop() item.PutListIDItemIDTopHandler {
 	})
 }
 
+// GetWaitlistHistory returns all items in waitlist's history
 func (h *handlers) GetWaitlistHistory() item.GetListIDHistoryHandler {
 	return item.GetListIDHistoryHandlerFunc(func(params item.GetListIDHistoryParams, principal *string) middleware.Responder {
 		listID, _ := utils.UUIDToBytes(params.ListID)
@@ -162,6 +198,7 @@ func (h *handlers) GetWaitlistHistory() item.GetListIDHistoryHandler {
 	})
 }
 
+// ReopenHistoryItem puts item from history back to waitlist
 func (h *handlers) ReopenHistoryItem() item.PutListIDItemIDReopenHandler {
 	return item.PutListIDItemIDReopenHandlerFunc(func(params item.PutListIDItemIDReopenParams, principal *string) middleware.Responder {
 		listID, _ := utils.UUIDToBytes(params.ListID)

--- a/service/waitlist/waitlist.go
+++ b/service/waitlist/waitlist.go
@@ -37,6 +37,9 @@ type Service interface {
 	// UpdateItem updates an item in a waitlist
 	UpdateItem(waitlistID []byte, item *models.Item) (*models.Item, error)
 
+	// UpdatePatient updates with new patient data all the items with specified patientID
+	UpdatePatient(patientID []byte, patient models.Patient) ([]*models.Item, error)
+
 	// MoveItemToTop moves item to the top of the list diregarding priority
 	MoveItemToTop(waitlistID, itemID []byte) (*models.Item, error)
 
@@ -72,6 +75,9 @@ type Storage interface {
 
 	// UpdateItem updates an item in a waitlist
 	UpdateItem(waitlistID []byte, item *models.Item) (*models.Item, error)
+
+	// UpdatePatient updates with new patient data all the items with specified patientID
+	UpdatePatient(patientID []byte, patient models.Patient) ([]*models.Item, error)
 
 	// MoveItemToTop moves item to the top of the list diregarding priority
 	MoveItemToTop(waitlistID, itemID []byte) (*models.Item, error)
@@ -134,6 +140,11 @@ func (s *service) CreateItem(waitlistID []byte, item *models.Item) (*models.Item
 // UpdateItem updates an item in a waitlist
 func (s *service) UpdateItem(waitlistID []byte, item *models.Item) (*models.Item, error) {
 	return s.storage.UpdateItem(waitlistID, item)
+}
+
+// UpdatePatient updates with new patient data all the items with specified patientID
+func (s *service) UpdatePatient(patientID []byte, patient models.Patient) ([]*models.Item, error) {
+	return s.storage.UpdatePatient(patientID, patient)
 }
 
 // MoveItemToTop moves item to the top of the list diregarding priority


### PR DESCRIPTION
ADD update patient data endpoint to waitlist API
- Add waitlist endpoint to update patient data in all waitlist items
  for the patient.
ADD update waitlist items wit patient info update  …
- Waitlist items now get updated when patient info data are updated.
- Closes: #139