### PR TITLE
FIX first diagnosis not displayed in summary

### DIFF
--- a/frontend/local/src/containers/waitlist/detail/add-diagnosis.js
+++ b/frontend/local/src/containers/waitlist/detail/add-diagnosis.js
@@ -46,7 +46,7 @@ class AddDiagnosis extends React.Component {
 
     getDiagnosisState(diagnosisIndex, waitlistItem) {
         let diagnosis =
-            diagnosisIndex && waitlistItem && waitlistItem.diagnoses && waitlistItem.diagnoses[diagnosisIndex]
+            diagnosisIndex !== undefined && waitlistItem && waitlistItem.diagnoses && waitlistItem.diagnoses[diagnosisIndex]
                 ? {
                       diagnosis: {
                           id: waitlistItem.diagnoses[diagnosisIndex].diagnosis,
@@ -78,7 +78,6 @@ class AddDiagnosis extends React.Component {
         }
 
         this.props.updateWaitlistItem(this.props.match.params.waitlistID, newItem)
-
         this.setState({
             diagnosis: this.getDiagnosisState(this.props.match.params.diagnosisIndex || newItem.diagnoses.length - 1, newItem)
         })


### PR DESCRIPTION
- While adding first diagnosis it was not displayed in the summary screen
  due to diagnosisIndex = 0 being treated as boolean false.
- Close: #161