### PR TITLE
UPD define explicitly array items in api specs

### DIFF
--- a/docs/api/discovery.yml
+++ b/docs/api/discovery.yml
@@ -389,12 +389,15 @@ definitions:
   Connections:
     type: array
     items:
-      type: object
-      properties:
-        key:
-          type: string
-        value:
-          type: string
+      $ref: '#/definitions/Connection'
+
+  Connection:
+    type: object
+    properties:
+      key:
+        type: string
+      value:
+        type: string
 
   Locations:
     type: array

--- a/docs/api/waitlist.yml
+++ b/docs/api/waitlist.yml
@@ -569,12 +569,15 @@ definitions:
     type: array
     readOnly: true
     items:
-      type: object
-      properties:
-        key:
-          type: string
-        value:
-          type: string
+      $ref: '#/definitions/PatientData'
+
+  PatientData:
+    type: object
+    properties:
+      key:
+        type: string
+      value:
+        type: string
 
   Complaint:
     description: Object describing patient's complaint

--- a/storage/discovery/diff.go
+++ b/storage/discovery/diff.go
@@ -86,8 +86,8 @@ func processCardDiff(tx db.DB, current *models.Card, new *models.Card) error {
 	return nil
 }
 
-func connectionsToMap(conns models.Connections) ([]string, map[string]*models.ConnectionsItems) {
-	m := make(map[string]*models.ConnectionsItems, len(conns))
+func connectionsToMap(conns models.Connections) ([]string, map[string]*models.Connection) {
+	m := make(map[string]*models.Connection, len(conns))
 	k := []string{}
 
 	for _, c := range conns {

--- a/storage/discovery/discovery.go
+++ b/storage/discovery/discovery.go
@@ -223,7 +223,7 @@ var getCard = func(tx db.DB, patientID strfmt.UUID) (*models.Card, error) {
 
 	// process connections
 	for _, conn := range p.Connections {
-		card.Connections = append(card.Connections, &models.ConnectionsItems{
+		card.Connections = append(card.Connections, &models.Connection{
 			Key:   conn.Key,
 			Value: conn.Value,
 		})

--- a/storage/discovery/discovery_test.go
+++ b/storage/discovery/discovery_test.go
@@ -30,11 +30,11 @@ var (
 	card       = &models.Card{
 		PatientID: uuid1,
 		Connections: models.Connections{
-			&models.ConnectionsItems{
+			&models.Connection{
 				Key:   "K1",
 				Value: "V1",
 			},
-			&models.ConnectionsItems{
+			&models.Connection{
 				Key:   "K2",
 				Value: "V2",
 			},
@@ -84,8 +84,8 @@ func TestCreate(t *testing.T) {
 			&models.Card{
 				PatientID: uuid1,
 				Connections: models.Connections{
-					&models.ConnectionsItems{Key: "K1", Value: "V1"},
-					&models.ConnectionsItems{Key: "K2", Value: "V2"},
+					&models.Connection{Key: "K1", Value: "V1"},
+					&models.Connection{Key: "K2", Value: "V2"},
 				},
 				Locations: models.Locations{uuid1},
 			},
@@ -153,8 +153,8 @@ func TestCreate(t *testing.T) {
 
 			// call the method
 			out, err := s.Create(models.Connections{
-				&models.ConnectionsItems{Key: "K1", Value: "V1"},
-				&models.ConnectionsItems{Key: "K2", Value: "V2"},
+				&models.Connection{Key: "K1", Value: "V1"},
+				&models.Connection{Key: "K2", Value: "V2"},
 			}, models.Locations{uuid1})
 
 			// check expected results
@@ -253,8 +253,8 @@ func TestUpdate(t *testing.T) {
 			&models.Card{
 				PatientID: uuid1,
 				Connections: models.Connections{
-					&models.ConnectionsItems{Key: "K2", Value: "V2.2"},
-					&models.ConnectionsItems{Key: "K3", Value: "V3"},
+					&models.Connection{Key: "K2", Value: "V2.2"},
+					&models.Connection{Key: "K3", Value: "V3"},
 				},
 				Locations: models.Locations{uuid2},
 			},
@@ -293,8 +293,8 @@ func TestUpdate(t *testing.T) {
 
 			// call the method
 			out, err := s.Update(uuid1, models.Connections{
-				&models.ConnectionsItems{Key: "K2", Value: "V2.2"},
-				&models.ConnectionsItems{Key: "K3", Value: "V3"},
+				&models.Connection{Key: "K2", Value: "V2.2"},
+				&models.Connection{Key: "K3", Value: "V3"},
 			}, models.Locations{uuid2})
 
 			// check expected results
@@ -348,8 +348,8 @@ func TestGet(t *testing.T) {
 			&models.Card{
 				PatientID: uuid1,
 				Connections: models.Connections{
-					&models.ConnectionsItems{Key: "K1", Value: "V1"},
-					&models.ConnectionsItems{Key: "K2", Value: "V2"},
+					&models.Connection{Key: "K1", Value: "V1"},
+					&models.Connection{Key: "K2", Value: "V2"},
 				},
 				Locations: models.Locations{uuid1},
 			},
@@ -633,8 +633,8 @@ func TestFind(t *testing.T) {
 				&models.Card{
 					PatientID: uuid1,
 					Connections: models.Connections{
-						&models.ConnectionsItems{Key: "K1", Value: "V1"},
-						&models.ConnectionsItems{Key: "K2", Value: "V2"},
+						&models.Connection{Key: "K1", Value: "V1"},
+						&models.Connection{Key: "K2", Value: "V2"},
 					},
 					Locations: models.Locations{uuid1},
 				},
@@ -666,8 +666,8 @@ func TestFind(t *testing.T) {
 				&models.Card{
 					PatientID: uuid1,
 					Connections: models.Connections{
-						&models.ConnectionsItems{Key: "K1", Value: "V1"},
-						&models.ConnectionsItems{Key: "K2", Value: "V2"},
+						&models.Connection{Key: "K1", Value: "V1"},
+						&models.Connection{Key: "K2", Value: "V2"},
 					},
 					Locations: models.Locations{uuid1},
 				},

--- a/storage/waitlist/items_test.go
+++ b/storage/waitlist/items_test.go
@@ -219,7 +219,7 @@ func TestUpdatePatient(t *testing.T) {
 		Priority:      swag.Int64(1),
 		PatientID:     swag.String(patient1ID.String()),
 		Patient: models.Patient{
-			&models.PatientItems{
+			&models.PatientData{
 				Key:   "status",
 				Value: "added",
 			},
@@ -231,7 +231,7 @@ func TestUpdatePatient(t *testing.T) {
 		Priority:      swag.Int64(1),
 		PatientID:     swag.String(patient1ID.String()),
 		Patient: models.Patient{
-			&models.PatientItems{
+			&models.PatientData{
 				Key:   "status",
 				Value: "added",
 			},
@@ -241,7 +241,7 @@ func TestUpdatePatient(t *testing.T) {
 	updatedItems, err := storage.UpdatePatient(
 		patient1ID.Bytes(),
 		models.Patient{
-			&models.PatientItems{
+			&models.PatientData{
 				Key:   "status",
 				Value: "updated",
 			},


### PR DESCRIPTION
- After go-swagger update the naming given to automatically generated
  structs for non-explicitly defined objects being array items has changed.
  To fix it, all non-explicitly define array items objects were defined.