### PR TITLE
Fix storagesync conflict behaviour

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -6,7 +6,7 @@ Not all values are used by all commands, documentation for each command contains
 
 Environment variable | Default value | Description
 ------------ | ------------- | -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
+`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components.*
 `DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
 `KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
 `CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*

--- a/cmd/batchStorageSync/README.md
+++ b/cmd/batchStorageSync/README.md
@@ -5,7 +5,7 @@ Command for scheduled local->cloud storage sync batch recheck (performing actual
 ## Configuration environment variables
 Environment variable | Default value | Description
 ------------ | ------------- | -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
+`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components.*
 `DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
 `KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
 `CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*

--- a/cmd/cloudAuth/README.md
+++ b/cmd/cloudAuth/README.md
@@ -54,7 +54,7 @@ It currently contains following entities:
 ## Configuration environment variables
 Environment variable | Default value | Description
 -----------| ------------| -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
+`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components.*
 `DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
 `KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
 `CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*

--- a/cmd/cloudStatusReporter/README.md
+++ b/cmd/cloudStatusReporter/README.md
@@ -5,7 +5,7 @@ Service for reporting status of services and internet in general.
 ## Configuration environment variables
 Environment variable | Default value | Description
 ------------ | ------------- | -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
+`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components.*
 `DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
 `KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
 `CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*

--- a/cmd/cloudStorage/README.md
+++ b/cmd/cloudStorage/README.md
@@ -5,7 +5,7 @@ Cloud file storage service.
 ## Configuration environment variables
 Environment variable | Default value | Description
 ------------ | ------------- | -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
+`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components.*
 `DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
 `KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
 `CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*

--- a/cmd/localAuth/README.md
+++ b/cmd/localAuth/README.md
@@ -10,7 +10,7 @@ On initialization database is pulled from **cloudAuth**. Information about initi
 ## Configuration environment variables
 Environment variable | Default value | Description
 ------------ | ------------- | -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
+`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components.*
 `DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
 `KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
 `CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*

--- a/cmd/localStatusReporter/README.md
+++ b/cmd/localStatusReporter/README.md
@@ -5,7 +5,7 @@ Service for reporting status of services and local instance connectivity to Clou
 ## Configuration environment variables
 Environment variable | Default value | Description
 ------------ | ------------- | -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
+`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components.*
 `DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
 `KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
 `CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*

--- a/cmd/localStorage/README.md
+++ b/cmd/localStorage/README.md
@@ -3,30 +3,31 @@
 Local file storage service.
 
 ## Configuration environment variables
-Environment variable | Default value | Description
------------- | ------------- | -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
-`DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
-`KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
-`CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*
-`S3_ENDPOINT` | `cloudMinio:9000` | *S3 object storage endpoint.*
-`S3_ACCESS_KEY` | `cloud` | *S3 object storage access key.*
-`S3_REGION` | `us-east-1` | *S3 object storage region.*
-`S3_SECRET` | *none*, ***required*** | *S3 object storage secret.*
-`STORAGE_ENCRYPTION_KEY` |  *none*, ***required*** | *Base64-encoded storage encryption key.*
-`AUTH_HOST` | `localAuth` | *Hostname of adjacent (local) Auth service API.*
-`AUTH_PATH` | `auth` | *Root path of adjacent (local) Auth service API.*
-`SERVER_HOST` | `0.0.0.0` | *Hostname under which service exposes its HTTP servers.*
-`SERVER_PORT` | `443` | *Port under which service exposes its main HTTP server.*
-`METRICS_PORT` | `9090` | *Port under which service exposes its metrics HTTP server.*
-`METRICS_NAMESPACE` | `""` | *Namespace/path under which service exposes its metrics HTTP server.*
-`STATUS_PORT` | `4433` | *Port under which service exposes its metrics HTTP server.*
-`STATUS_NAMESPACE` | `""` | *Namespace/path under which service exposes its status HTTP server.*
-`NATS_ADDR` | `localNats:4242` | *NATS server address.*
-`NATS_USERNAME` | `nats` | *Username used to connect to NATS.*
-`NATS_SECRET` | *none*, ***required*** | *Secret used to connect to NATS.*
-`NATS_CONN_RETRIES` | `5` | *Number of attempts to connect to NATS.*
-`NATS_CONN_WAIT` | `500ms` | *Initial wait time before reattempting to connect to NATS after failed attempt.*
-`NATS_CONN_WAIT_FACTOR` | `3.0` | *Factor by which wait time increases after each consecutive failed retry.*
-`NATS_CLUSTER_ID` | `localNats` | *NATS Streaming cluster ID*
-`NATS_CLIENT_ID` | `localStorage` | *NATS Streaming client ID*
+
+| Environment variable     | Default value          | Description                                                                                                                         |
+| ------------------------ | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `DOMAIN_TYPE`            | `global`               | _Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components._ |
+| `DOMAIN_ID`              | `*`                    | _Domain in which component is operating, normally it should be '_' for all cloud components and clinic ID for local components.\*   |
+| `KEY_PATH`               | _none_, **_required_** | _Path to service's private key (PEM-formatted file)._                                                                               |
+| `CERT_PATH`              | _none_, **_required_** | _Path to service's public key (PEM-formatted file)._                                                                                |
+| `S3_ENDPOINT`            | `cloudMinio:9000`      | _S3 object storage endpoint._                                                                                                       |
+| `S3_ACCESS_KEY`          | `cloud`                | _S3 object storage access key._                                                                                                     |
+| `S3_REGION`              | `us-east-1`            | _S3 object storage region._                                                                                                         |
+| `S3_SECRET`              | _none_, **_required_** | _S3 object storage secret._                                                                                                         |
+| `STORAGE_ENCRYPTION_KEY` | _none_, **_required_** | _Base64-encoded storage encryption key._                                                                                            |
+| `AUTH_HOST`              | `localAuth`            | _Hostname of adjacent (local) Auth service API._                                                                                    |
+| `AUTH_PATH`              | `auth`                 | _Root path of adjacent (local) Auth service API._                                                                                   |
+| `SERVER_HOST`            | `0.0.0.0`              | _Hostname under which service exposes its HTTP servers._                                                                            |
+| `SERVER_PORT`            | `443`                  | _Port under which service exposes its main HTTP server._                                                                            |
+| `METRICS_PORT`           | `9090`                 | _Port under which service exposes its metrics HTTP server._                                                                         |
+| `METRICS_NAMESPACE`      | `""`                   | _Namespace/path under which service exposes its metrics HTTP server._                                                               |
+| `STATUS_PORT`            | `4433`                 | _Port under which service exposes its metrics HTTP server._                                                                         |
+| `STATUS_NAMESPACE`       | `""`                   | _Namespace/path under which service exposes its status HTTP server._                                                                |
+| `NATS_ADDR`              | `localNats:4242`       | _NATS server address._                                                                                                              |
+| `NATS_USERNAME`          | `nats`                 | _Username used to connect to NATS._                                                                                                 |
+| `NATS_SECRET`            | _none_, **_required_** | _Secret used to connect to NATS._                                                                                                   |
+| `NATS_CONN_RETRIES`      | `5`                    | _Number of attempts to connect to NATS._                                                                                            |
+| `NATS_CONN_WAIT`         | `500ms`                | _Initial wait time before reattempting to connect to NATS after failed attempt._                                                    |
+| `NATS_CONN_WAIT_FACTOR`  | `3.0`                  | _Factor by which wait time increases after each consecutive failed retry._                                                          |
+| `NATS_CLUSTER_ID`        | `localNats`            | _NATS Streaming cluster ID_                                                                                                         |
+| `NATS_CLIENT_ID`         | `localStorage`         | _NATS Streaming client ID_                                                                                                          |

--- a/cmd/storageSync/README.md
+++ b/cmd/storageSync/README.md
@@ -5,7 +5,7 @@ Service consuming sync messages from local Storage published via NATS streaming.
 ## Configuration environment variables
 Environment variable | Default value | Description
 ------------ | ------------- | -------------
-`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'global' for all cloud components and 'clinic' for local components.*
+`DOMAIN_TYPE` | `global` | *Domain in which component is operating, normally it should be 'cloud' for all cloud components and 'clinic' for local components.*
 `DOMAIN_ID` | `*` |  *Domain in which component is operating, normally it should be '*' for all cloud components and clinic ID for local components.*
 `KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
 `CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*

--- a/cmd/waitlist/README.md
+++ b/cmd/waitlist/README.md
@@ -3,19 +3,22 @@
 Local waitlist service.
 
 ## Configuration environment variables
-Environment variable | Default value | Description
------------- | ------------- | -------------
-`BOLT_DB_FILEPATH` | `/data/waitlist.db` | *Path to Bolt DB file in which waitlist data are stored.*
-`KEY_PATH` | *none*, ***required*** | *Path to service's private key (PEM-formatted file).*
-`CERT_PATH` | *none*, ***required*** | *Path to service's public key (PEM-formatted file).*
-`STORAGE_ENCRYPTION_KEY` | *none*, ***required*** | *Base64-encoded storage encryption key.*
-`SERVER_HOST` | `0.0.0.0` | *Hostname under which service exposes its HTTP servers.*
-`SERVER_PORT` | `443` | *Port under which service exposes its main HTTP server.*
-`METRICS_PORT` | `9090` | *Port under which service exposes its metrics HTTP server.*
-`METRICS_NAMESPACE` | `""` | *Namespace/path under which service exposes its metrics HTTP server.*
-`STATUS_PORT` | `4433` | *Port under which service exposes its metrics HTTP server.*
-`STATUS_NAMESPACE` | `""` | *Namespace/path under which service exposes its status HTTP server.*
-`STORAGE_HOST` | `localAuth` | *Hostname of adjacent Storage service API.*
-`STORAGE_PATH` | `auth` | *Root path of adjacent Storage service API.*
-`AUTH_HOST` | `localAuth` | *Hostname of adjacent auth service API*
-`AUTH_PATH` | `auth` | *Root path of adjacent auth service API*
+
+| Environment variable     | Default value                          | Description                                                           |
+| ------------------------ | -------------------------------------- | --------------------------------------------------------------------- |
+| `BOLT_DB_FILEPATH`       | `/data/waitlist.db`                    | _Path to Bolt DB file in which waitlist data are stored._             |
+| `DEFAULT_LIST_ID`        | `22afd921-0630-49f4-89a8-d1ad7639ee83` | _ID of default waitlist that is ensured to always exist._             |
+| `DEFAULT_LIST_NAME`      | `default`                              | _Name of default waitlist that is ensured to always exist._           |
+| `KEY_PATH`               | _none_, **_required_**                 | _Path to service's private key (PEM-formatted file)._                 |
+| `CERT_PATH`              | _none_, **_required_**                 | _Path to service's public key (PEM-formatted file)._                  |
+| `STORAGE_ENCRYPTION_KEY` | _none_, **_required_**                 | _Base64-encoded storage encryption key._                              |
+| `SERVER_HOST`            | `0.0.0.0`                              | _Hostname under which service exposes its HTTP servers._              |
+| `SERVER_PORT`            | `443`                                  | _Port under which service exposes its main HTTP server._              |
+| `METRICS_PORT`           | `9090`                                 | _Port under which service exposes its metrics HTTP server._           |
+| `METRICS_NAMESPACE`      | `""`                                   | _Namespace/path under which service exposes its metrics HTTP server._ |
+| `STATUS_PORT`            | `4433`                                 | _Port under which service exposes its metrics HTTP server._           |
+| `STATUS_NAMESPACE`       | `""`                                   | _Namespace/path under which service exposes its status HTTP server._  |
+| `STORAGE_HOST`           | `localAuth`                            | _Hostname of adjacent Storage service API._                           |
+| `STORAGE_PATH`           | `auth`                                 | _Root path of adjacent Storage service API._                          |
+| `AUTH_HOST`              | `localAuth`                            | _Hostname of adjacent auth service API_                               |
+| `AUTH_PATH`              | `auth`                                 | _Root path of adjacent auth service API_                              |

--- a/service/storage/handlers.go
+++ b/service/storage/handlers.go
@@ -296,8 +296,6 @@ func (h *handlers) SyncFile() operations.SyncFileHandler {
 			switch err {
 			case ErrAlreadyExists:
 				return operations.NewSyncFileOK().WithPayload(fd)
-			case ErrAlreadyExistsConflict:
-				return operations.NewSyncFileConflict()
 			default:
 				return operations.NewSyncFileInternalServerError().WithPayload(&models.Error{
 					Code:    "server_error",
@@ -317,8 +315,6 @@ func (h *handlers) SyncFileDelete() operations.SyncFileDeleteHandler {
 			switch err {
 			case ErrNotFound:
 				return operations.NewSyncFileDeleteNotFound()
-			case ErrDeleted:
-				return operations.NewSyncFileDeleteConflict()
 			default:
 				return operations.NewSyncFileDeleteInternalServerError().WithPayload(&models.Error{
 					Code:    "server_error",


### PR DESCRIPTION
FIX storageSync checksum conflict behaviour  …
- In case of checksum conflict "synced" file will always
  take precedence as the sync is one way so the "syncing" deployment
  is the one from which the file originates and in case previous
  attempt to sync was interrupted, it should be allowed to overwrite.