### PR TITLE
Fixes for storage sync

### DIFF
--- a/docs/api/storage.yml
+++ b/docs/api/storage.yml
@@ -126,10 +126,6 @@ paths:
       operationId: fileGet
       produces:
         - application/octet-stream
-        - application/json; charset=utf-8
-        - text/openEhrXml
-        - text/openEhrJson
-        - application/x-collection+json
 
       parameters:
         - in: path
@@ -150,7 +146,7 @@ paths:
           schema:
             type: file
           headers:
-            Content-Type:
+            X-Content-Type:
               type: string
               description: Content type of the file
             X-Created:
@@ -335,10 +331,6 @@ paths:
       operationId: fileGetVersion
       produces:
         - application/octet-stream
-        - application/json; charset=utf-8
-        - text/openEhrXml
-        - text/openEhrJson
-        - application/x-collection+json
 
       parameters:
         - in: path
@@ -365,7 +357,7 @@ paths:
           schema:
             type: file
           headers:
-            Content-Type:
+            X-Content-Type:
               type: string
               description: Content type of the file
             X-Created:
@@ -532,7 +524,7 @@ paths:
         200:
           description: File found
           headers:
-            Content-Type:
+            X-Content-Type:
               type: string
               description: Content type of the file
             X-Created:

--- a/service/storage/handlers.go
+++ b/service/storage/handlers.go
@@ -70,7 +70,7 @@ func (h *handlers) FileGet() operations.FileGetHandler {
 
 		return utils.UseProducer(operations.NewFileGetOK().
 			WithPayload(r).
-			WithContentType(fd.ContentType).
+			WithXContentType(fd.ContentType).
 			WithXCreated(fd.Created).
 			WithXVersion(fd.Version).
 			WithXArchetype(fd.Archetype).
@@ -99,7 +99,7 @@ func (h *handlers) FileGetVersion() operations.FileGetVersionHandler {
 
 		return utils.UseProducer(operations.NewFileGetVersionOK().
 			WithPayload(r).
-			WithContentType(fd.ContentType).
+			WithXContentType(fd.ContentType).
 			WithXCreated(fd.Created).
 			WithXVersion(fd.Version).
 			WithXArchetype(fd.Archetype).
@@ -264,7 +264,7 @@ func (h *handlers) SyncFileMetadata() operations.SyncFileMetadataHandler {
 		}
 
 		return operations.NewSyncFileMetadataOK().
-			WithContentType(fd.ContentType).
+			WithXContentType(fd.ContentType).
 			WithXCreated(fd.Created).
 			WithXVersion(fd.Version).
 			WithXArchetype(fd.Archetype).

--- a/services/traefik/traefik.toml
+++ b/services/traefik/traefik.toml
@@ -194,7 +194,7 @@ address = ":8080"
   [frontends.cloudstorage]
   backend = "cloudstorage"
     [frontends.cloudstorage.routes.route1]
-    rule = "Host:iryo.cloud;PathPrefix:/api/v1/storage;AddPrefix:/e;ReplacePathRegexStrip: ^/api/v1/(.*)$ /$storage"
+    rule = "Host:iryo.cloud;PathPrefixStrip:/api/v1/storage;AddPrefix:/storage"
 
   [frontends.cloudMinio]
   backend = "cloudMinio"

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -361,7 +361,6 @@ func (s *s3storage) Delete(_ context.Context, bucketID, fileID, version string) 
 	// first objects keys will be saved to array to prevent deleting any if listing fails
 	objKeys := []string{}
 	for info := range s.client.ListObjectsV2(bucketID, prefix, false, nil) {
-		s.logger.Info().Msg(fmt.Sprintf("%v", info))
 		if info.Err != nil {
 			s.logger.Error().Err(info.Err).Str("cmd", "s3::Delete").Msg("Failed to list all objects")
 			return errors.Wrap(info.Err, "Failed to list all objects")
@@ -374,6 +373,7 @@ func (s *s3storage) Delete(_ context.Context, bucketID, fileID, version string) 
 	for _, objKey := range objKeys {
 		ch <- objKey
 	}
+	close(ch)
 
 	for removeObjErr := range s.client.RemoveObjects(bucketID, ch) {
 		err = removeObjErr.Err

--- a/sync/storage/handlers.go
+++ b/sync/storage/handlers.go
@@ -59,7 +59,7 @@ func (h *handlers) SyncFile(ctx context.Context, bucketID, fileID, version strin
 				Str("bucket", bucketID).
 				Str("fileID", fileID).
 				Str("version", version).
-				Msg("File does not exist in source operations.")
+				Msg("File does not exist in source storage.")
 
 			// File might have been already deleted; mark as succesful
 			return ResultSyncNotNeeded, nil
@@ -69,7 +69,7 @@ func (h *handlers) SyncFile(ctx context.Context, bucketID, fileID, version strin
 			Str("bucket", bucketID).
 			Str("fileID", fileID).
 			Str("version", version).
-			Msg("Error on trying to fetch file from source operations.")
+			Msg("Error on trying to fetch file from source storage.")
 		return ResultError, err
 	}
 
@@ -98,7 +98,7 @@ func (h *handlers) SyncFile(ctx context.Context, bucketID, fileID, version strin
 		syncParams.SetLabels(formatLabelsFromHeader(resp.XLabels))
 	}
 
-	syncParams.SetContentType(resp.ContentType)
+	syncParams.SetContentType(resp.XContentType)
 	syncParams.SetFile(runtime.NamedReader("FileReader", &buf))
 	ok, created, err := h.destination.SyncFile(syncParams, h.destinationAuth)
 
@@ -222,7 +222,9 @@ func (h *handlers) needsSync(ctx context.Context, bucketID, fileID, version, sou
 				Str("bucket", bucketID).
 				Str("fileID", fileID).
 				Str("version", version).
-				Msg("File already exists in destination storage and has different checksum.")
+				Msg("File already exists in destination storage and has different checksum, resync.")
+
+			return true, nil
 		}
 		// Nothing to do
 		return false, nil

--- a/utils/producers.go
+++ b/utils/producers.go
@@ -35,7 +35,7 @@ func UseProducer(responder middleware.Responder, p producer) middleware.Responde
 			responder.WriteResponse(rw, runtime.ByteStreamProducer())
 
 		case FileProducer:
-			// content type is expected to be set already
+			rw.Header().Set(runtime.HeaderContentType, "application/octet-stream")
 			responder.WriteResponse(rw, runtime.ByteStreamProducer())
 
 		default:


### PR DESCRIPTION
- UPD content type of files always octet/stream
    - Header content-type when returning storage files will be always set to application/octet-stream to prevent problems with consuming response using go-swagger client.
    - Actual file content type of the file as stored in its metadata is returned in header X-Content-Type.
- FIX Resyncing files with wrong checksum
    - Channel of objects was not being closed.
    - NeedsSync method was giving false response.
- FIX cloudStorage frontend in traefik config