### PR TITLE
FIX use single db role for report gen services

### DIFF
--- a/cmd/batchDataExporter/README.md
+++ b/cmd/batchDataExporter/README.md
@@ -24,7 +24,7 @@ Command for scheduled export of data from files in storage to DB to allow for re
 | `DB_PASSWORD`                     | _none_, **_required_**                   | _PostgreSQL DB password._                                                                                                                                                       |
 | `POSTGRES_HOST`                   | `postgres`                               | _Hostname on which postgres is exposed on._                                                                                                                                     |
 | `POSTGRES_DATABASE`               | `reports`                                | _Postgres database to connect to._                                                                                                                                              |
-| `POSTGRES_ROLE`                   | `dataexportservice`                      | _Postgres role to assume once connected._                                                                                                                                       |
+| `POSTGRES_ROLE`                   | `reportsservice`                         | _Postgres role to assume once connected._                                                                                                                                       |
 | `DB_DETAILED_LOG`                 | `false`                                  | _Allows to enable detailed DB statements log, otherwise only errors are printed._                                                                                               |
 
 ## Sanitizer configuration

--- a/cmd/batchDataExporter/config.go
+++ b/cmd/batchDataExporter/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	DbPassword    string `env:"DB_PASSWORD,required"`
 	PGHost        string `env:"POSTGRES_HOST" envDefault:"postgres"`
 	PGDatabase    string `env:"POSTGRES_DATABASE" envDefault:"reports"`
-	PGRole        string `env:"POSTGRES_ROLE" envDefault:"dataexportservice"`
+	PGRole        string `env:"POSTGRES_ROLE" envDefault:"reportsservice"`
 	DbDetailedLog bool   `env:"DB_DETAILED_LOG" envDefault:"false"`
 
 	BoltDBFilepath string `env:"BOLT_DB_FILEPATH" envDefault:"/data/batchDataExporter.db"`

--- a/cmd/batchReportGenerator/README.md
+++ b/cmd/batchReportGenerator/README.md
@@ -20,7 +20,7 @@ Command for scheduled generation of CSV reports from EHR files data exported pre
 | `DB_PASSWORD`                     | _none_, **_required_**                                            | _PostgreSQL DB password._                                                                                                              |
 | `POSTGRES_HOST`                   | `postgres`                                                        | _Hostname on which postgres is exposed on._                                                                                            |
 | `POSTGRES_DATABASE`               | `reports`                                                         | _Postgres database to connect to._                                                                                                     |
-| `POSTGRES_ROLE`                   | `dataexportservice`                                               | _Postgres role to assume once connected._                                                                                              |
+| `POSTGRES_ROLE`                   | `reportsservice`                                                  | _Postgres role to assume once connected._                                                                                              |
 | `DB_DETAILED_LOG`                 | `false`                                                           | _Allows to enable detailed DB statements log, otherwise only errors are printed._                                                      |
 
 ## Report specification files

--- a/cmd/batchReportGenerator/config.go
+++ b/cmd/batchReportGenerator/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	DbPassword    string `env:"DB_PASSWORD,required"`
 	PGHost        string `env:"POSTGRES_HOST" envDefault:"postgres"`
 	PGDatabase    string `env:"POSTGRES_DATABASE" envDefault:"reports"`
-	PGRole        string `env:"POSTGRES_ROLE" envDefault:"reportgenerationservice"`
+	PGRole        string `env:"POSTGRES_ROLE" envDefault:"reportsservice"`
 	DbDetailedLog bool   `env:"DB_DETAILED_LOG" envDefault:"false"`
 
 	BoltDBFilepath string `env:"BOLT_DB_FILEPATH" envDefault:"/data/batchReportGenerator.db"`

--- a/docs/k8s/reportsInit.sql
+++ b/docs/k8s/reportsInit.sql
@@ -1,13 +1,11 @@
 -- reports
-CREATE ROLE dataexportservice;
-CREATE ROLE reportgenerationservice;
+CREATE ROLE reportsservice;
 CREATE DATABASE reports;
 
-GRANT ALL PRIVILEGES ON DATABASE reports TO dataexportservice;
-GRANT ALL PRIVILEGES ON DATABASE reports TO reportgenerationservice;
+GRANT ALL PRIVILEGES ON DATABASE reports TO reportsservice;
 
 CREATE USER batchdataexporter WITH PASSWORD 'vdj4532ejuf270774460687e0043825466861116';
-GRANT dataexportservice to batchdataexporter;
+GRANT reportsservice to batchdataexporter;
 
 CREATE USER reportgenerator WITH PASSWORD 'mo99c7f3plq6690298807931203675165588007e';
-GRANT reportgenerationservice to reportgenerator;
+GRANT reportsservice to reportgenerator;

--- a/docs/k8s/reportsSchema.sql
+++ b/docs/k8s/reportsSchema.sql
@@ -8,7 +8,7 @@ CREATE TABLE files (
     PRIMARY KEY (file_id)
 );
 
-ALTER TABLE files OWNER TO dataexportservice;
+ALTER TABLE files OWNER TO reportsservice;
 
 CREATE INDEX created_idx ON files (created_at ASC);
 CREATE INDEX patient_idx ON files (patient_id);

--- a/services/postgres/files/reportsInit.sql
+++ b/services/postgres/files/reportsInit.sql
@@ -1,13 +1,11 @@
 -- reports
-CREATE ROLE dataexportservice;
-CREATE ROLE reportgenerationservice;
+CREATE ROLE reportsservice;
 CREATE DATABASE reports;
 
-GRANT ALL PRIVILEGES ON DATABASE reports TO dataexportservice;
-GRANT ALL PRIVILEGES ON DATABASE reports TO reportgenerationservice;
+GRANT ALL PRIVILEGES ON DATABASE reports TO reportsservice;
 
 CREATE USER batchdataexporter WITH PASSWORD 'batchdataexporter';
-GRANT dataexportservice to batchdataexporter;
+GRANT reportsservice to batchdataexporter;
 
 CREATE USER reportgenerator WITH PASSWORD 'reportgenerator';
-GRANT reportgenerationservice to reportgenerator;
+GRANT reportsservice to reportgenerator;

--- a/services/postgres/files/reportsSchema.sql
+++ b/services/postgres/files/reportsSchema.sql
@@ -8,7 +8,7 @@ CREATE TABLE files (
     PRIMARY KEY (file_id)
 );
 
-ALTER TABLE files OWNER TO dataexportservice;
+ALTER TABLE files OWNER TO reportsservice;
 
 CREATE INDEX created_idx ON files (created_at ASC);
 CREATE INDEX patient_idx ON files (patient_id);


### PR DESCRIPTION
- Instead of using separate db roles use single "reportsservice" db role
  for services responsible for report generation.