### PR TITLE
Various clinic frontend changes

### DIFF
--- a/frontend/cloud/src/containers/clinics/list.js
+++ b/frontend/cloud/src/containers/clinics/list.js
@@ -161,144 +161,138 @@ class Clinics extends React.Component {
         }
 
         return (
-            <div id="clinics">
-                <div className="row">
-                    <table className="table">
-                        <thead>
-                            <tr>
-                                <th className="w-7" scope="col">
-                                    #
-                                </th>
-                                <th className="w-20" scope="col">
-                                    Name
-                                </th>
-                                <th className="w-20" scope="col">
-                                    Organization
-                                </th>
-                                <th className="w-20" scope="col">
-                                    Location
-                                </th>
-                                <th />
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {_.map(this.state.clinics, (clinic, i) => (
-                                <React.Fragment key={clinic.id || i}>
-                                    <tr
-                                        className={classnames({
-                                            "table-active": this.state.selectedClinicID === clinic.id,
-                                            "table-edit": props.canEdit && clinic.edit
-                                        })}
-                                    >
-                                        <th className="w-7" scope="row">
-                                            {i + 1}
-                                        </th>
-                                        <td className="w-20">
-                                            {props.canEdit && clinic.edit ? (
-                                                <input
-                                                    value={clinic.name || ""}
-                                                    onChange={this.editClinicName(i)}
-                                                    type="text"
-                                                    className="form-control"
-                                                    placeholder="Clinic Name"
-                                                    aria-label="Clinic Name"
-                                                />
+            <React.Fragment>
+                <table className="table">
+                    <thead>
+                        <tr>
+                            <th className="w-7" scope="col">
+                                #
+                            </th>
+                            <th className="w-20" scope="col">
+                                Name
+                            </th>
+                            <th className="w-20" scope="col">
+                                Organization
+                            </th>
+                            <th className="w-20" scope="col">
+                                Location
+                            </th>
+                            <th />
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {_.map(this.state.clinics, (clinic, i) => (
+                            <React.Fragment key={clinic.id || i}>
+                                <tr
+                                    className={classnames({
+                                        "table-active": this.state.selectedClinicID === clinic.id,
+                                        "table-edit": props.canEdit && clinic.edit
+                                    })}
+                                >
+                                    <th className="w-7" scope="row">
+                                        {i + 1}
+                                    </th>
+                                    <td className="w-20">
+                                        {props.canEdit && clinic.edit ? (
+                                            <input
+                                                value={clinic.name || ""}
+                                                onChange={this.editClinicName(i)}
+                                                type="text"
+                                                className="form-control"
+                                                placeholder="Clinic Name"
+                                                aria-label="Clinic Name"
+                                            />
+                                        ) : (
+                                            clinic.name
+                                        )}
+                                    </td>
+                                    <td className="w-20">
+                                        {props.canEdit && clinic.edit ? (
+                                            <select className="form-control" value={clinic.organization || ""} onChange={this.editOrganizationID(i)}>
+                                                <option value="">Select organization</option>
+                                                {_.map(props.organizations, organization => (
+                                                    <option key={organization.id} value={organization.id}>
+                                                        {organization.name}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                        ) : (
+                                            <Link to={`/organizations/${clinic.organization}`}>{props.organizations[clinic.organization].name}</Link>
+                                        )}
+                                    </td>
+                                    <td className="w-20">
+                                        {props.canEdit && clinic.edit ? (
+                                            <select className="form-control" value={clinic.location || ""} onChange={this.editLocationID(i)}>
+                                                <option value="">Select location</option>
+                                                {_.map(props.locations, location => (
+                                                    <option key={location.id} value={location.id}>
+                                                        {location.name}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                        ) : (
+                                            <Link to={`/locations/${clinic.location}`}>{props.locations[clinic.location].name}</Link>
+                                        )}
+                                    </td>
+                                    <td className="text-right">
+                                        {props.canEdit ? (
+                                            clinic.edit ? (
+                                                <div>
+                                                    <button
+                                                        className="btn btn-secondary"
+                                                        disabled={clinic.saving}
+                                                        type="button"
+                                                        onClick={this.cancelNewClinic(i)}
+                                                    >
+                                                        Remove
+                                                    </button>
+                                                    <button
+                                                        className="btn btn-primary"
+                                                        disabled={clinic.saving || !clinic.canSave}
+                                                        type="button"
+                                                        onClick={this.saveClinic(i)}
+                                                    >
+                                                        Add
+                                                    </button>
+                                                </div>
                                             ) : (
-                                                clinic.name
-                                            )}
-                                        </td>
-                                        <td className="w-20">
-                                            {props.canEdit && clinic.edit ? (
-                                                <select className="form-control" value={clinic.organization || ""} onChange={this.editOrganizationID(i)}>
-                                                    <option value="">Select organization</option>
-                                                    {_.map(props.organizations, organization => (
-                                                        <option key={organization.id} value={organization.id}>
-                                                            {organization.name}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                            ) : (
-                                                <Link to={`/organizations/${clinic.organization}`}>{props.organizations[clinic.organization].name}</Link>
-                                            )}
-                                        </td>
-                                        <td className="w-20">
-                                            {props.canEdit && clinic.edit ? (
-                                                <select className="form-control" value={clinic.location || ""} onChange={this.editLocationID(i)}>
-                                                    <option value="">Select location</option>
-                                                    {_.map(props.locations, location => (
-                                                        <option key={location.id} value={location.id}>
-                                                            {location.name}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                            ) : (
-                                                <Link to={`/locations/${clinic.location}`}>{props.locations[clinic.location].name}</Link>
-                                            )}
-                                        </td>
-                                        <td className="text-right">
-                                            {props.canEdit ? (
-                                                clinic.edit ? (
-                                                    <div>
-                                                        <button
-                                                            className="btn btn-secondary"
-                                                            disabled={clinic.saving}
-                                                            type="button"
-                                                            onClick={this.cancelNewClinic(i)}
-                                                        >
-                                                            Remove
+                                                <div>
+                                                    {this.state.selectedClinicID === clinic.id ? (
+                                                        <button className="btn btn-link" type="button" onClick={() => this.props.push(`/clinics`)}>
+                                                            Hide Users
+                                                            <span className="arrow-up-icon" />
                                                         </button>
-                                                        <button
-                                                            className="btn btn-primary"
-                                                            disabled={clinic.saving || !clinic.canSave}
-                                                            type="button"
-                                                            onClick={this.saveClinic(i)}
-                                                        >
-                                                            Add
+                                                    ) : (
+                                                        <button className="btn btn-link" type="button" onClick={() => this.props.push(`/clinics/${clinic.id}`)}>
+                                                            Show Users
+                                                            <span className="arrow-down-icon" />
                                                         </button>
-                                                    </div>
-                                                ) : (
-                                                    <div>
-                                                        {this.state.selectedClinicID === clinic.id ? (
-                                                            <button className="btn btn-link" type="button" onClick={() => this.props.push(`/clinics`)}>
-                                                                Hide Users
-                                                                <span className="arrow-up-icon" />
-                                                            </button>
-                                                        ) : (
-                                                            <button
-                                                                className="btn btn-link"
-                                                                type="button"
-                                                                onClick={() => this.props.push(`/clinics/${clinic.id}`)}
-                                                            >
-                                                                Show Users
-                                                                <span className="arrow-down-icon" />
-                                                            </button>
-                                                        )}
-                                                        <button className="btn btn-link" type="button" onClick={this.removeClinic(i)}>
-                                                            <span className="remove-link">Remove</span>
-                                                        </button>
-                                                    </div>
-                                                )
-                                            ) : null}
+                                                    )}
+                                                    <button className="btn btn-link" type="button" onClick={this.removeClinic(i)}>
+                                                        <span className="remove-link">Remove</span>
+                                                    </button>
+                                                </div>
+                                            )
+                                        ) : null}
+                                    </td>
+                                </tr>
+                                {this.state.selectedClinicID === clinic.id ? (
+                                    <tr className="table-active">
+                                        <td colSpan="5" className="row-details-container">
+                                            <UsersList clinicID={clinic.id} />
                                         </td>
                                     </tr>
-                                    {this.state.selectedClinicID === clinic.id ? (
-                                        <tr className="table-active">
-                                            <td colSpan="5" className="row-details-container">
-                                                <UsersList clinicID={clinic.id} />
-                                            </td>
-                                        </tr>
-                                    ) : null}
-                                </React.Fragment>
-                            ))}
-                        </tbody>
-                    </table>
-                    {props.canEdit ? (
-                        <button type="button" className="btn btn-link" disabled={this.state.edit ? true : null} onClick={this.newClinic()}>
-                            Add Clinic
-                        </button>
-                    ) : null}
-                </div>
-            </div>
+                                ) : null}
+                            </React.Fragment>
+                        ))}
+                    </tbody>
+                </table>
+                {props.canEdit ? (
+                    <button type="button" className="btn btn-link" disabled={this.state.edit ? true : null} onClick={this.newClinic()}>
+                        Add Clinic
+                    </button>
+                ) : null}
+            </React.Fragment>
         )
     }
 }

--- a/frontend/local/src/containers/patients/detail/history.js
+++ b/frontend/local/src/containers/patients/detail/history.js
@@ -97,299 +97,272 @@ let ChildHistory = ({ patient }) => (
     </React.Fragment>
 )
 
-let BirthData = ({ patient, fetchCodes }) => (
-    <React.Fragment>
+let BirthData = ({ patient, fetchCodes }) => {
+    return patient.deliveryType || patient.prematurity || patient.weeksAtBirth || patient.weightAtBirth || patient.heightAtBirth ? (
         <div className="section">
             <div className="name">Birth data</div>
-            {patient.deliveryType || patient.prematurity || patient.weeksAtBirth || patient.weightAtBirth || patient.heightAtBirth ? (
-                <div className="values">
-                    <div className="row">
-                        <Column width="4" label="Delivery type" value={patient.deliveryType} key="deliveryType" codes={fetchCodes("deliveryType")} />
-                        <Column width="4" label="Prematurity" value={patient.prematurity === "true" ? "Yes" : "No"} key="prematurity" />
-                    </div>
+            <div className="values">
+                <div className="row">
+                    <Column width="4" label="Delivery type" value={patient.deliveryType} key="deliveryType" codes={fetchCodes("deliveryType")} />
+                    <Column width="4" label="Prematurity" value={patient.prematurity === "true" ? "Yes" : "No"} key="prematurity" />
+                </div>
 
-                    <div className="row">
-                        <Column width="4" label="Weeks at birth" value={patient.weeksAtBirth} unit="weeks" key="weeksAtBirth" />
-                        <Column width="4" label="Weight at birth" value={patient.weightAtBirth} unit="grams" key="weightAtBirth" />
-                        <Column width="4" label="Height at birth" value={patient.heightAtBirth} unit="cm" key="heightAtBirth" />
-                    </div>
+                <div className="row">
+                    <Column width="4" label="Weeks at birth" value={patient.weeksAtBirth} unit="weeks" key="weeksAtBirth" />
+                    <Column width="4" label="Weight at birth" value={patient.weightAtBirth} unit="grams" key="weightAtBirth" />
+                    <Column width="4" label="Height at birth" value={patient.heightAtBirth} unit="cm" key="heightAtBirth" />
                 </div>
-            ) : (
-                <div className="values">
-                    <dl>
-                        <dd>No information has been collected.</dd>
-                    </dl>
-                </div>
-            )}
+            </div>
         </div>
-    </React.Fragment>
-)
+    ) : null
+}
 
 BirthData = connect(state => ({}), {
     fetchCodes: getCodes
 })(BirthData)
 
-let BabyHabits = ({ patient, fetchCodes }) => (
-    <React.Fragment>
+let BabyHabits = ({ patient, fetchCodes }) => {
+    return patient.breastfeeding ||
+        patient.babyEatsAndDrinks ||
+        patient.babyWetDiapers ||
+        patient.babyBowelMovements ||
+        patient.babyBowelMovementsComment ||
+        patient.babySleep ||
+        patient.babySleepOnBack ||
+        patient.babyVitaminD ||
+        patient.babyGetsAround ||
+        patient.babyCommunicates ||
+        patient.babyAnyoneSmokes ? (
         <div className="section">
             <div className="name">Habits</div>
-            {patient.breastfeeding ||
-            patient.babyEatsAndDrinks ||
-            patient.babyWetDiapers ||
-            patient.babyBowelMovements ||
-            patient.babyBowelMovementsComment ||
-            patient.babySleep ||
-            patient.babySleepOnBack ||
-            patient.babyVitaminD ||
-            patient.babyGetsAround ||
-            patient.babyCommunicates ||
-            patient.babyAnyoneSmokes ? (
-                <div className="values">
-                    <dl>
-                        {patient.breastfeeding && (
-                            <div className="item" key="breastfeeding">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.breastfeeding === "true",
-                                        negative: patient.breastfeeding === "false"
-                                    })}
-                                >
-                                    {patient.breastfeeding === "true"
-                                        ? "Breastfeeding" + (patient.breastfeedingDuration ? ` for ${patient.breastfeedingDuration} weeks.` : ".")
-                                        : "No breastfeeding."}
-                                </dt>
+            <div className="values">
+                <dl>
+                    {patient.breastfeeding && (
+                        <div className="item" key="breastfeeding">
+                            <dt
+                                className={classnames({
+                                    positive: patient.breastfeeding === "true",
+                                    negative: patient.breastfeeding === "false"
+                                })}
+                            >
+                                {patient.breastfeeding === "true"
+                                    ? "Breastfeeding" + (patient.breastfeedingDuration ? ` for ${patient.breastfeedingDuration} weeks.` : ".")
+                                    : "No breastfeeding."}
+                            </dt>
+                        </div>
+                    )}
+                    {patient.babyEatsAndDrinks && (
+                        <div className="item" key="babyEatsAndDrinks">
+                            <div className="row">
+                                <Column
+                                    width="8"
+                                    label="What does your baby eat and drink?"
+                                    value={patient.babyEatsAndDrinks}
+                                    key="babyEatsAndDrinks"
+                                    codes={fetchCodes("babyFood")}
+                                />
                             </div>
-                        )}
-                        {patient.babyEatsAndDrinks && (
-                            <div className="item" key="babyEatsAndDrinks">
-                                <div className="row">
-                                    <Column
-                                        width="8"
-                                        label="What does your baby eat and drink?"
-                                        value={patient.babyEatsAndDrinks}
-                                        key="babyEatsAndDrinks"
-                                        codes={fetchCodes("babyFood")}
-                                    />
-                                </div>
+                        </div>
+                    )}
+                    {patient.babyWetDiapers && (
+                        <div className="item" key="babyWetDiapers">
+                            <div className="row">
+                                <Column width="8" label="How many diapers does your child wet in 24h?" value={patient.babyWetDiapers} key="babyWetDiapers" />
                             </div>
-                        )}
-                        {patient.babyWetDiapers && (
-                            <div className="item" key="babyWetDiapers">
-                                <div className="row">
-                                    <Column
-                                        width="8"
-                                        label="How many diapers does your child wet in 24h?"
-                                        value={patient.babyWetDiapers}
-                                        key="babyWetDiapers"
-                                    />
-                                </div>
+                        </div>
+                    )}
+                    {patient.babyBowelMovements && (
+                        <div className="item" key="babyBowelMovements">
+                            <div className="row">
+                                <Column
+                                    width="8"
+                                    label="How frequent does your baby have bowel movements?"
+                                    value={patient.babyBowelMovements}
+                                    key="babyBowelMovements"
+                                />
                             </div>
-                        )}
-                        {patient.babyBowelMovements && (
-                            <div className="item" key="babyBowelMovements">
-                                <div className="row">
-                                    <Column
-                                        width="8"
-                                        label="How frequent does your baby have bowel movements?"
-                                        value={patient.babyBowelMovements}
-                                        key="babyBowelMovements"
-                                    />
-                                </div>
+                        </div>
+                    )}
+                    {patient.babyBowelMovementsComment && (
+                        <div className="item" key="babyBowelMovementsComment">
+                            <div className="row">
+                                <Column
+                                    width="8"
+                                    label="Describe baby's bowel movements"
+                                    value={patient.babyBowelMovementsComment}
+                                    key="babyBowelMovementsComment"
+                                />
                             </div>
-                        )}
-                        {patient.babyBowelMovementsComment && (
-                            <div className="item" key="babyBowelMovementsComment">
-                                <div className="row">
-                                    <Column
-                                        width="8"
-                                        label="Describe baby's bowel movements"
-                                        value={patient.babyBowelMovementsComment}
-                                        key="babyBowelMovementsComment"
-                                    />
-                                </div>
+                        </div>
+                    )}
+                    {patient.babySleep && (
+                        <div className="item" key="babySleep">
+                            <dt
+                                className={classnames({
+                                    positive: patient.babySleep === "true",
+                                    negative: patient.babySleep === "false"
+                                })}
+                            >
+                                {patient.babySleep === "true" ? "Satisfied with child's sleep." : "Not satisfied with child's sleep."}
+                            </dt>
+                            {patient.babySleepComment && <dd className="withIconComment">{patient.babySleepComment}</dd>}
+                        </div>
+                    )}
+                    {patient.babySleepsOnBack && (
+                        <div className="item" key="babySleepsOnBack">
+                            <dt
+                                className={classnames({
+                                    positive: patient.babySleepsOnBack === "true",
+                                    negative: patient.babySleepsOnBack === "false"
+                                })}
+                            >
+                                {patient.babySleepsOnBack === "true" ? "Baby sleeps on its back." : "Baby does not sleep on its back."}
+                            </dt>
+                        </div>
+                    )}
+                    {patient.babyVitaminD && (
+                        <div className="item" key="babyVitaminD">
+                            <dt
+                                className={classnames({
+                                    positive: patient.babyVitaminD === "true",
+                                    negative: patient.babyVitaminD === "false"
+                                })}
+                            >
+                                {patient.babyVitaminD === "true" ? "Baby takes vitamin D." : "Baby does not take vitamin D."}
+                            </dt>
+                        </div>
+                    )}
+                    {patient.babyGetsAround && (
+                        <div className="item" key="babyGetsAround">
+                            <div className="row">
+                                <Column width="8" label="How does your child get around?" value={patient.babyGetsAround} key="babyGetsAround" />
                             </div>
-                        )}
-                        {patient.babySleep && (
-                            <div className="item" key="babySleep">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.babySleep === "true",
-                                        negative: patient.babySleep === "false"
-                                    })}
-                                >
-                                    {patient.babySleep === "true" ? "Satisfied with child's sleep." : "Not satisfied with child's sleep."}
-                                </dt>
-                                {patient.babySleepComment && <dd className="withIconComment">{patient.babySleepComment}</dd>}
+                        </div>
+                    )}
+                    {patient.babyCommunicates && (
+                        <div className="item" key="babyCommunicates">
+                            <div className="row">
+                                <Column
+                                    width="8"
+                                    label="How does your child communicate?"
+                                    value={patient.babyCommunicates}
+                                    key="babyCommunicates"
+                                    codes={fetchCodes("childCommunication")}
+                                />
                             </div>
-                        )}
-                        {patient.babySleepsOnBack && (
-                            <div className="item" key="babySleepsOnBack">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.babySleepsOnBack === "true",
-                                        negative: patient.babySleepsOnBack === "false"
-                                    })}
-                                >
-                                    {patient.babySleepsOnBack === "true" ? "Baby sleeps on its back." : "Baby does not sleep on its back."}
-                                </dt>
-                            </div>
-                        )}
-                        {patient.babyVitaminD && (
-                            <div className="item" key="babyVitaminD">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.babyVitaminD === "true",
-                                        negative: patient.babyVitaminD === "false"
-                                    })}
-                                >
-                                    {patient.babyVitaminD === "true" ? "Baby takes vitamin D." : "Baby does not take vitamin D."}
-                                </dt>
-                            </div>
-                        )}
-                        {patient.babyGetsAround && (
-                            <div className="item" key="babyGetsAround">
-                                <div className="row">
-                                    <Column width="8" label="How does your child get around?" value={patient.babyGetsAround} key="babyGetsAround" />
-                                </div>
-                            </div>
-                        )}
-                        {patient.babyCommunicates && (
-                            <div className="item" key="babyCommunicates">
-                                <div className="row">
-                                    <Column
-                                        width="8"
-                                        label="How does your child communicate?"
-                                        value={patient.babyCommunicates}
-                                        key="babyCommunicates"
-                                        codes={fetchCodes("childCommunication")}
-                                    />
-                                </div>
-                            </div>
-                        )}
-                        {patient.babyAnyoneSmokes && (
-                            <div className="item" key="babyAnyoneSmokes">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.babyAnyoneSmokes === "false",
-                                        negative: patient.babyAnyoneSmokes === "true"
-                                    })}
-                                >
-                                    {patient.babySleep === "true" ? "No smokers in the house." : "Smokers in the house."}
-                                </dt>
-                                {patient.babyNumberOfSmokers && <dd className="withIconComment">{patient.babyNumberOfSmokers} smokers.</dd>}
-                            </div>
-                        )}
-                    </dl>
-                </div>
-            ) : (
-                <div className="values">
-                    <dl>
-                        <dd>No information has been collected.</dd>
-                    </dl>
-                </div>
-            )}
+                        </div>
+                    )}
+                    {patient.babyAnyoneSmokes && (
+                        <div className="item" key="babyAnyoneSmokes">
+                            <dt
+                                className={classnames({
+                                    positive: patient.babyAnyoneSmokes === "false",
+                                    negative: patient.babyAnyoneSmokes === "true"
+                                })}
+                            >
+                                {patient.babySleep === "true" ? "No smokers in the house." : "Smokers in the house."}
+                            </dt>
+                            {patient.babyNumberOfSmokers && <dd className="withIconComment">{patient.babyNumberOfSmokers} smokers.</dd>}
+                        </div>
+                    )}
+                </dl>
+            </div>
         </div>
-    </React.Fragment>
-)
+    ) : null
+}
 
 BabyHabits = connect(state => ({}), {
     fetchCodes: getCodes
 })(BabyHabits)
 
-let ChildVaccination = ({ patient }) => (
-    <React.Fragment>
+let ChildVaccination = ({ patient }) => {
+    return patient.vaccinationUpToDate ||
+        patient.vaccinationCertificates ||
+        patient.tuberculosisTested ||
+        patient.tuberculosisTestResult ||
+        patient.vaccinationReaction ? (
         <div className="section">
             <div className="name">Vaccination</div>
             <div className="values">
-                {patient.vaccinationUpToDate ||
-                patient.vaccinationCertificates ||
-                patient.tuberculosisTested ||
-                patient.tuberculosisTestResult ||
-                patient.vaccinationReaction ? (
-                    <dl>
-                        {patient.vaccinationUpToDate && (
-                            <div className="item" key="vaccinationUpToDate">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.vaccinationUpToDate === "true",
-                                        negative: patient.vaccinationUpToDate === "false"
-                                    })}
-                                >
-                                    {patient.vaccinationUpToDate === "true"
-                                        ? "Up to date with the home country vaccination schedule."
-                                        : "Not up to date with the home country vaccination schedule."}
-                                </dt>
-                            </div>
-                        )}
-                        {patient.vaccinationCertificates && (
-                            <div className="item" key="vaccinationCertificates">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.vaccinationCertificates === "true",
-                                        negative: patient.vaccinationCertificates === "false"
-                                    })}
-                                >
-                                    {patient.vaccinationCertificates === "true"
-                                        ? "Up to date with the home country vaccination schedule."
-                                        : "Not up to date with the home country vaccination schedule."}
-                                </dt>
-                            </div>
-                        )}
-                        {patient.tuberculosisTested && (
-                            <div className="item" key="tuberculosisTested">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.tuberculosisTested === "true",
-                                        negative: patient.tuberculosisTested === "false"
-                                    })}
-                                >
-                                    {patient.tuberculosisTested === "true"
-                                        ? "Child has been tested for tuberculosis."
-                                        : "Child has not been tested for tuberculosis."}
-                                </dt>
-                            </div>
-                        )}
-                        {patient.tuberculosisTestResult && (
-                            <div className="item" key="tuberculosisTestResult">
-                                <dt
-                                    className={classnames({
-                                        danger: patient.tuberculosisTestResult === "true"
-                                    })}
-                                >
-                                    {patient.tuberculosisTestResult === "true" ? "Positive result for tuberculosis." : "Negative result for tuberculosis."}
-                                </dt>
-                                {patient.tuberculosisAdditionalInvestigationDetails && (
-                                    <dd className="withIconComment">{patient.tuberculosisAdditionalInvestigationDetails}</dd>
-                                )}
-                            </div>
-                        )}
-                        {patient.vaccinationReaction && (
-                            <div className="item" key="vaccinationReaction">
-                                <dt
-                                    className={classnames({
-                                        danger: patient.vaccinationReaction === "true"
-                                    })}
-                                >
-                                    {patient.vaccinationReaction === "true"
-                                        ? "Child has experienced vaccination reaction."
-                                        : "Child has not experienced vaccination reaction."}
-                                </dt>
-                                {patient.vaccinationReactionDetails && <dd className="withIconComment">{patient.vaccinationReactionDetails}</dd>}
-                            </div>
-                        )}
-                    </dl>
-                ) : (
-                    <dl>
-                        <dd>No information has been collected</dd>
-                    </dl>
-                )}
+                <dl>
+                    {patient.vaccinationUpToDate && (
+                        <div className="item" key="vaccinationUpToDate">
+                            <dt
+                                className={classnames({
+                                    positive: patient.vaccinationUpToDate === "true",
+                                    negative: patient.vaccinationUpToDate === "false"
+                                })}
+                            >
+                                {patient.vaccinationUpToDate === "true"
+                                    ? "Up to date with the home country vaccination schedule."
+                                    : "Not up to date with the home country vaccination schedule."}
+                            </dt>
+                        </div>
+                    )}
+                    {patient.vaccinationCertificates && (
+                        <div className="item" key="vaccinationCertificates">
+                            <dt
+                                className={classnames({
+                                    positive: patient.vaccinationCertificates === "true",
+                                    negative: patient.vaccinationCertificates === "false"
+                                })}
+                            >
+                                {patient.vaccinationCertificates === "true"
+                                    ? "Up to date with the home country vaccination schedule."
+                                    : "Not up to date with the home country vaccination schedule."}
+                            </dt>
+                        </div>
+                    )}
+                    {patient.tuberculosisTested && (
+                        <div className="item" key="tuberculosisTested">
+                            <dt
+                                className={classnames({
+                                    positive: patient.tuberculosisTested === "true",
+                                    negative: patient.tuberculosisTested === "false"
+                                })}
+                            >
+                                {patient.tuberculosisTested === "true"
+                                    ? "Child has been tested for tuberculosis."
+                                    : "Child has not been tested for tuberculosis."}
+                            </dt>
+                        </div>
+                    )}
+                    {patient.tuberculosisTestResult && (
+                        <div className="item" key="tuberculosisTestResult">
+                            <dt
+                                className={classnames({
+                                    danger: patient.tuberculosisTestResult === "true"
+                                })}
+                            >
+                                {patient.tuberculosisTestResult === "true" ? "Positive result for tuberculosis." : "Negative result for tuberculosis."}
+                            </dt>
+                            {patient.tuberculosisAdditionalInvestigationDetails && (
+                                <dd className="withIconComment">{patient.tuberculosisAdditionalInvestigationDetails}</dd>
+                            )}
+                        </div>
+                    )}
+                    {patient.vaccinationReaction && (
+                        <div className="item" key="vaccinationReaction">
+                            <dt
+                                className={classnames({
+                                    danger: patient.vaccinationReaction === "true"
+                                })}
+                            >
+                                {patient.vaccinationReaction === "true"
+                                    ? "Child has experienced vaccination reaction."
+                                    : "Child has not experienced vaccination reaction."}
+                            </dt>
+                            {patient.vaccinationReactionDetails && <dd className="withIconComment">{patient.vaccinationReactionDetails}</dd>}
+                        </div>
+                    )}
+                </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    ) : null
+}
 
-let Allergies = ({ patient }) => (
-    <React.Fragment>
+let Allergies = ({ patient }) => {
+    return (patient.allergies || []).length === 0 ? null : (
         <div className="section">
             <div className="name">Allergies</div>
             <div className="values">
@@ -405,15 +378,14 @@ let Allergies = ({ patient }) => (
                             )}
                         </div>
                     ))}
-                    {(patient.allergies || []).length === 0 && <dd>None</dd>}
                 </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    )
+}
 
-let Immunization = ({ patient }) => (
-    <React.Fragment>
+let Immunization = ({ patient }) => {
+    return (patient.immunizations || []).length === 0 ? null : (
         <div className="section">
             <div className="name">Immunization</div>
             <div className="values">
@@ -425,15 +397,14 @@ let Immunization = ({ patient }) => (
                             {item.date && <dd>{moment(item.date).format("Do MMMM Y")}</dd>}
                         </div>
                     ))}
-                    {(patient.immunizations || []).length === 0 && <dd>None</dd>}
                 </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    )
+}
 
-let ChronicDiseases = ({ patient }) => (
-    <React.Fragment>
+let ChronicDiseases = ({ patient }) => {
+    return (patient.chronicDiseases || []).length === 0 ? null : (
         <div className="section">
             <div className="name">Chronic diseases</div>
             <div className="values">
@@ -445,15 +416,14 @@ let ChronicDiseases = ({ patient }) => (
                             {item.date && <dd className="withIconComment">{moment(item.date).format("Do MMMM Y")}</dd>}
                         </div>
                     ))}
-                    {(patient.chronicDiseases || []).length === 0 && <dd>None</dd>}
                 </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    )
+}
 
-let Injuries = ({ patient }) => (
-    <React.Fragment>
+let Injuries = ({ patient }) => {
+    return (patient.injuries || []).length === 0 ? null : (
         <div className="section">
             <div className="name">Injuries &amp; handicaps</div>
             <div className="values">
@@ -465,15 +435,14 @@ let Injuries = ({ patient }) => (
                             {item.date && <dd>{moment(item.date).format("Do MMMM Y")}</dd>}
                         </div>
                     ))}
-                    {(patient.injuries || []).length === 0 && <dd>None</dd>}
                 </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    )
+}
 
-let Surgeries = ({ patient }) => (
-    <React.Fragment>
+let Surgeries = ({ patient }) => {
+    return (patient.surgeries || []).length === 0 ? null : (
         <div className="section">
             <div className="name">Surgeries</div>
             <div className="values">
@@ -485,15 +454,14 @@ let Surgeries = ({ patient }) => (
                             {item.date && <dd>{moment(item.date).format("Do MMMM Y")}</dd>}
                         </div>
                     ))}
-                    {(patient.surgeries || []).length === 0 && <dd>None</dd>}
                 </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    )
+}
 
-let Medications = ({ patient }) => (
-    <React.Fragment>
+let Medications = ({ patient }) => {
+    return (patient.medications || []).length === 0 ? null : (
         <div className="section">
             <div className="name">Additional medications</div>
             <div className="values">
@@ -508,230 +476,212 @@ let Medications = ({ patient }) => (
                 </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    )
+}
 
-let Habits = ({ patient }) => (
-    <React.Fragment>
+let Habits = ({ patient }) => {
+    return patient.habits_smoking === "true" || patient.habits_drugs === "true" ? (
         <div className="section">
             <div className="name">Habits</div>
             <div className="values">
-                {patient.habits_smoking === "true" || patient.habits_drugs === "true" ? (
-                    <dl>
-                        {patient.habits_smoking === "true" && (
-                            <div className="item" key="habits_smoking">
-                                <dt className="danger">Smoker</dt>
-                                {patient.habits_smoking_comment && <dd className="withIconComment">{patient.habits_smoking_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.habits_drugs === "true" && (
-                            <div className="item" key="habits_drugs">
-                                <dt className="danger">Taking drugs</dt>
-                                {patient.habits_drugs_comment && <dd className="withIconComment">{patient.habits_drugs_comment}</dd>}
-                            </div>
-                        )}
-                    </dl>
-                ) : (
-                    <dl>
-                        <dd>None</dd>
-                    </dl>
-                )}
+                <dl>
+                    {patient.habits_smoking === "true" && (
+                        <div className="item" key="habits_smoking">
+                            <dt className="danger">Smoker</dt>
+                            {patient.habits_smoking_comment && <dd className="withIconComment">{patient.habits_smoking_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.habits_drugs === "true" && (
+                        <div className="item" key="habits_drugs">
+                            <dt className="danger">Taking drugs</dt>
+                            {patient.habits_drugs_comment && <dd className="withIconComment">{patient.habits_drugs_comment}</dd>}
+                        </div>
+                    )}
+                </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    ) : null
+}
 
-let BabyConditions = ({ patient }) => (
-    <React.Fragment>
+let BabyConditions = ({ patient }) => {
+    return patient.conditions_basic_hygiene ||
+        patient.conditions_clean_water ||
+        patient.conditions_electricity ||
+        patient.conditions_food_supply ||
+        patient.conditions_heating ? (
         <div className="section">
             <div className="name">Conditions</div>
             <div className="values">
-                {patient.conditions_basic_hygiene ||
-                patient.conditions_clean_water ||
-                patient.conditions_electricity ||
-                patient.conditions_food_supply ||
-                patient.conditions_heating ? (
-                    <dl>
-                        {patient.conditions_basic_hygiene && (
-                            <div className="item" key="conditions_basic_hygiene">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_basic_hygiene === "true",
-                                        negative: patient.conditions_basic_hygiene === "false"
-                                    })}
-                                >
-                                    {patient.conditions_basic_hygiene === "true"
-                                        ? "Has resources for basic hygiene."
-                                        : "Does not have resources for basic hygiene."}
-                                </dt>
-                                {patient.conditions_basic_hygiene_comment && <dd className="withIconComment">{patient.conditions_basic_hygiene_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_clean_water && (
-                            <div className="item" key="conditions_clean_water">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_clean_water === "true",
-                                        negative: patient.conditions_clean_water === "false"
-                                    })}
-                                >
-                                    {patient.conditions_clean_water === "true" ? "Has access to clean water." : "No access to clean water."}
-                                </dt>
-                                {patient.conditions_clean_water_comment && <dd className="withIconComment">{patient.conditions_clean_water_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_food_supply && (
-                            <div className="item" key="conditions_food_supply">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_food_supply === "true",
-                                        negative: patient.conditions_food_supply === "false"
-                                    })}
-                                >
-                                    {patient.conditions_food_supply === "true" ? "Has sufficient food supply." : "Does not have sufficient food supply."}
-                                </dt>
-                                {patient.conditions_food_supply_comment && <dd className="withIconComment">{patient.conditions_food_supply_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_heating && (
-                            <div className="item" key="conditions_heating">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_heating === "true",
-                                        negative: patient.conditions_heating === "false"
-                                    })}
-                                >
-                                    {patient.conditions_heating === "true" ? "Accomodation has heating." : "Accomodation does not have heating."}
-                                </dt>
-                                {patient.conditions_heating_comment && <dd className="withIconComment">{patient.conditions_heating_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_electricity && (
-                            <div className="item" key="conditions_electricity">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_electricity === "true",
-                                        negative: patient.conditions_electricity === "false"
-                                    })}
-                                >
-                                    {patient.conditions_electricity === "true" ? "Accomodation has electricity." : "Accomodation does not have electricity."}
-                                </dt>
-                                {patient.conditions_electricity_comment && <dd className="withIconComment">{patient.conditions_electricity_comment}</dd>}
-                            </div>
-                        )}
-                    </dl>
-                ) : (
-                    <dl>
-                        <dd>No information has been collected.</dd>
-                    </dl>
-                )}
+                <dl>
+                    {patient.conditions_basic_hygiene && (
+                        <div className="item" key="conditions_basic_hygiene">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_basic_hygiene === "true",
+                                    negative: patient.conditions_basic_hygiene === "false"
+                                })}
+                            >
+                                {patient.conditions_basic_hygiene === "true"
+                                    ? "Has resources for basic hygiene."
+                                    : "Does not have resources for basic hygiene."}
+                            </dt>
+                            {patient.conditions_basic_hygiene_comment && <dd className="withIconComment">{patient.conditions_basic_hygiene_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_clean_water && (
+                        <div className="item" key="conditions_clean_water">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_clean_water === "true",
+                                    negative: patient.conditions_clean_water === "false"
+                                })}
+                            >
+                                {patient.conditions_clean_water === "true" ? "Has access to clean water." : "No access to clean water."}
+                            </dt>
+                            {patient.conditions_clean_water_comment && <dd className="withIconComment">{patient.conditions_clean_water_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_food_supply && (
+                        <div className="item" key="conditions_food_supply">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_food_supply === "true",
+                                    negative: patient.conditions_food_supply === "false"
+                                })}
+                            >
+                                {patient.conditions_food_supply === "true" ? "Has sufficient food supply." : "Does not have sufficient food supply."}
+                            </dt>
+                            {patient.conditions_food_supply_comment && <dd className="withIconComment">{patient.conditions_food_supply_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_heating && (
+                        <div className="item" key="conditions_heating">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_heating === "true",
+                                    negative: patient.conditions_heating === "false"
+                                })}
+                            >
+                                {patient.conditions_heating === "true" ? "Accomodation has heating." : "Accomodation does not have heating."}
+                            </dt>
+                            {patient.conditions_heating_comment && <dd className="withIconComment">{patient.conditions_heating_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_electricity && (
+                        <div className="item" key="conditions_electricity">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_electricity === "true",
+                                    negative: patient.conditions_electricity === "false"
+                                })}
+                            >
+                                {patient.conditions_electricity === "true" ? "Accomodation has electricity." : "Accomodation does not have electricity."}
+                            </dt>
+                            {patient.conditions_electricity_comment && <dd className="withIconComment">{patient.conditions_electricity_comment}</dd>}
+                        </div>
+                    )}
+                </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    ) : null
+}
 
-let Conditions = ({ patient }) => (
-    <React.Fragment>
+let Conditions = ({ patient }) => {
+    return patient.conditions_basic_hygiene ||
+        patient.conditions_clean_water ||
+        patient.conditions_electricity ||
+        patient.conditions_food_supply ||
+        patient.conditions_good_appetite ||
+        patient.conditions_heating ? (
         <div className="section">
             <div className="name">Conditions</div>
             <div className="values">
-                {patient.conditions_basic_hygiene ||
-                patient.conditions_clean_water ||
-                patient.conditions_electricity ||
-                patient.conditions_food_supply ||
-                patient.conditions_good_appetite ||
-                patient.conditions_heating ? (
-                    <dl>
-                        {patient.conditions_basic_hygiene && (
-                            <div className="item" key="conditions_basic_hygiene">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_basic_hygiene === "true",
-                                        negative: patient.conditions_basic_hygiene === "false"
-                                    })}
-                                >
-                                    {patient.conditions_basic_hygiene === "true"
-                                        ? "Has resources for basic hygiene."
-                                        : "Does not have resources for basic hygiene."}
-                                </dt>
-                                {patient.conditions_basic_hygiene_comment && <dd className="withIconComment">{patient.conditions_basic_hygiene_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_clean_water && (
-                            <div className="item" key="conditions_clean_water">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_clean_water === "true",
-                                        negative: patient.conditions_clean_water === "false"
-                                    })}
-                                >
-                                    {patient.conditions_clean_water === "true" ? "Has access to clean water." : "No access to clean water."}
-                                </dt>
-                                {patient.conditions_clean_water_comment && <dd className="withIconComment">{patient.conditions_clean_water_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_food_supply && (
-                            <div className="item" key="conditions_food_supply">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_food_supply === "true",
-                                        negative: patient.conditions_food_supply === "false"
-                                    })}
-                                >
-                                    {patient.conditions_food_supply === "true" ? "Has sufficient food supply." : "Does not have sufficient food supply."}
-                                </dt>
-                                {patient.conditions_food_supply_comment && <dd className="withIconComment">{patient.conditions_food_supply_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_good_appetite && (
-                            <div className="item" key="conditions_good_appetite">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_good_appetite === "true",
-                                        negative: patient.conditions_good_appetite === "false"
-                                    })}
-                                >
-                                    {patient.conditions_good_appetite === "true" ? "Has good appetite." : "Does not have good appetite."}
-                                </dt>
-                                {patient.conditions_good_appetite_comment && <dd className="withIconComment">{patient.conditions_good_appetite_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_heating && (
-                            <div className="item" key="conditions_heating">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_heating === "true",
-                                        negative: patient.conditions_heating === "false"
-                                    })}
-                                >
-                                    {patient.conditions_heating === "true" ? "Accomodation has heating." : "Accomodation does not have heating."}
-                                </dt>
-                                {patient.conditions_heating_comment && <dd className="withIconComment">{patient.conditions_heating_comment}</dd>}
-                            </div>
-                        )}
-                        {patient.conditions_electricity && (
-                            <div className="item" key="conditions_electricity">
-                                <dt
-                                    className={classnames({
-                                        positive: patient.conditions_electricity === "true",
-                                        negative: patient.conditions_electricity === "false"
-                                    })}
-                                >
-                                    {patient.conditions_electricity === "true" ? "Accomodation has electricity." : "Accomodation does not have electricity."}
-                                </dt>
-                                {patient.conditions_electricity_comment && <dd className="withIconComment">{patient.conditions_electricity_comment}</dd>}
-                            </div>
-                        )}
-                    </dl>
-                ) : (
-                    <dl>
-                        <dd>None</dd>
-                    </dl>
-                )}
+                <dl>
+                    {patient.conditions_basic_hygiene && (
+                        <div className="item" key="conditions_basic_hygiene">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_basic_hygiene === "true",
+                                    negative: patient.conditions_basic_hygiene === "false"
+                                })}
+                            >
+                                {patient.conditions_basic_hygiene === "true"
+                                    ? "Has resources for basic hygiene."
+                                    : "Does not have resources for basic hygiene."}
+                            </dt>
+                            {patient.conditions_basic_hygiene_comment && <dd className="withIconComment">{patient.conditions_basic_hygiene_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_clean_water && (
+                        <div className="item" key="conditions_clean_water">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_clean_water === "true",
+                                    negative: patient.conditions_clean_water === "false"
+                                })}
+                            >
+                                {patient.conditions_clean_water === "true" ? "Has access to clean water." : "No access to clean water."}
+                            </dt>
+                            {patient.conditions_clean_water_comment && <dd className="withIconComment">{patient.conditions_clean_water_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_food_supply && (
+                        <div className="item" key="conditions_food_supply">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_food_supply === "true",
+                                    negative: patient.conditions_food_supply === "false"
+                                })}
+                            >
+                                {patient.conditions_food_supply === "true" ? "Has sufficient food supply." : "Does not have sufficient food supply."}
+                            </dt>
+                            {patient.conditions_food_supply_comment && <dd className="withIconComment">{patient.conditions_food_supply_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_good_appetite && (
+                        <div className="item" key="conditions_good_appetite">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_good_appetite === "true",
+                                    negative: patient.conditions_good_appetite === "false"
+                                })}
+                            >
+                                {patient.conditions_good_appetite === "true" ? "Has good appetite." : "Does not have good appetite."}
+                            </dt>
+                            {patient.conditions_good_appetite_comment && <dd className="withIconComment">{patient.conditions_good_appetite_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_heating && (
+                        <div className="item" key="conditions_heating">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_heating === "true",
+                                    negative: patient.conditions_heating === "false"
+                                })}
+                            >
+                                {patient.conditions_heating === "true" ? "Accomodation has heating." : "Accomodation does not have heating."}
+                            </dt>
+                            {patient.conditions_heating_comment && <dd className="withIconComment">{patient.conditions_heating_comment}</dd>}
+                        </div>
+                    )}
+                    {patient.conditions_electricity && (
+                        <div className="item" key="conditions_electricity">
+                            <dt
+                                className={classnames({
+                                    positive: patient.conditions_electricity === "true",
+                                    negative: patient.conditions_electricity === "false"
+                                })}
+                            >
+                                {patient.conditions_electricity === "true" ? "Accomodation has electricity." : "Accomodation does not have electricity."}
+                            </dt>
+                            {patient.conditions_electricity_comment && <dd className="withIconComment">{patient.conditions_electricity_comment}</dd>}
+                        </div>
+                    )}
+                </dl>
             </div>
         </div>
-    </React.Fragment>
-)
+    ) : null
+}
 
 class EditHistory extends React.Component {
     constructor(props) {

--- a/frontend/local/src/containers/patients/detail/index.js
+++ b/frontend/local/src/containers/patients/detail/index.js
@@ -109,7 +109,7 @@ class PatientDetail extends React.Component {
                                 patient.weightAtBirth && (
                                     <div className="col-sm-4">
                                         <h5>Weight</h5>
-                                        {patient.weightAtBirth} grams
+                                        {patient.weightAtBirth} g
                                     </div>
                                 )
                             )}

--- a/frontend/local/src/containers/patients/detail/style.scss
+++ b/frontend/local/src/containers/patients/detail/style.scss
@@ -657,7 +657,6 @@ dt {
 
 .medicalData {
     .section {
-        padding-left: 50px;
         position: relative;
         padding-top: 15px;
         padding-bottom: 0px;

--- a/frontend/shared/containers/patient/card.js
+++ b/frontend/shared/containers/patient/card.js
@@ -14,7 +14,9 @@ const PatientCard = ({ data, big, withoutImage }) => {
     const gender = data.gender === "CODED-at0310" ? "M" : data.gender === "CODED-at0311" ? "F" : "?"
     const dob = moment(data.dateOfBirth)
     const dobString = dob.format("Do MMM Y")
-    const age = moment().diff(dob, "years")
+    const ageYears = moment().diff(dob, "years")
+    const ageMonths = moment().diff(dob, "months")
+    const ageWeeks = moment().diff(dob, "weeks")
 
     return (
         <div className={classnames("patientCard", { big })}>
@@ -25,7 +27,7 @@ const PatientCard = ({ data, big, withoutImage }) => {
                 </div>
                 <div className="dob">
                     {dobString}
-                    <span className="age">{age} y</span>
+                    <span className="age">{ageYears < 2 ? (ageMonths < 3 ? `${ageWeeks} w` : `${ageMonths} m`) : `${ageYears} y`}</span>
                     {gender}
                 </div>
             </div>

--- a/frontend/shared/icons/medical-data-active.svg
+++ b/frontend/shared/icons/medical-data-active.svg
@@ -1,5 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30">
-    <g fill="none" fill-rule="evenodd">
-        <path stroke="#2B333E" stroke-linecap="round" stroke-width="2" d="M9 15h2.5l1-3 1 6 2-8 2 9 1-4H21"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>3F2207C8-0655-4F3B-A378-E9C0E915F48F</title>
+    <desc>Created with sketchtool.</desc>
+    <defs></defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="navigation/Icon/medicalDataActive">
+            <g id="navigationIconWaitingList"></g>
+            <path d="M9,16 C8.44771525,16 8,15.5522847 8,15 C8,14.4477153 8.44771525,14 9,14 L10.7792408,14 L12.8244983,7.86422738 L13.6959657,13.0930316 L15.5572549,5.6478748 L17.5572549,14.6478748 L17.7192236,14 L21,14 C21.5522847,14 22,14.4477153 22,15 C22,15.5522847 21.5522847,16 21,16 L19.2807764,16 L17.4427451,23.3521252 L15.4427451,14.3521252 L13.3040343,22.9069684 L12.1528729,16 L9,16 Z" id="Line" fill="#2B333E" fill-rule="nonzero"></path>
+        </g>
     </g>
 </svg>

--- a/frontend/shared/icons/medical-data-inactive.svg
+++ b/frontend/shared/icons/medical-data-inactive.svg
@@ -1,5 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30">
-    <g fill="none" fill-rule="evenodd">
-        <path stroke="#C4C4CC" stroke-linecap="round" stroke-width="2" d="M9 15h2.5l1-3 1 6 2-8 2 9 1-4H21"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>F53EEFE3-501A-46BA-ABCC-07E76B6613DF</title>
+    <desc>Created with sketchtool.</desc>
+    <defs></defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="navigation/Icon/medicalDataInactive">
+            <g id="navigationIconWaitingList"></g>
+            <g id="Group" transform="translate(6.000000, 13.000000)"></g>
+            <path d="M9,16 C8.44771525,16 8,15.5522847 8,15 C8,14.4477153 8.44771525,14 9,14 L10.7792408,14 L12.8244983,7.86422738 L13.6959657,13.0930316 L15.5572549,5.6478748 L17.5572549,14.6478748 L17.7192236,14 L21,14 C21.5522847,14 22,14.4477153 22,15 C22,15.5522847 21.5522847,16 21,16 L19.2807764,16 L17.4427451,23.3521252 L15.4427451,14.3521252 L13.3040343,22.9069684 L12.1528729,16 L9,16 Z" id="Line" fill="#C4C4CC" fill-rule="nonzero"></path>
+        </g>
     </g>
 </svg>

--- a/frontend/shared/styles/index.scss
+++ b/frontend/shared/styles/index.scss
@@ -166,6 +166,7 @@ main {
     margin-left: 230px;
 
     & > .container {
+        margin-left: 0px;
         margin-top: 50px;
     }
 }


### PR DESCRIPTION
- UPD align medical data to the left
- FIX patient sidebar details alignment
    - Patient sidebar details are to be aligned to the left.
- FIX clinics list alignment
    - Clinics list was the only one aligned differently.
- FIX correct medical data icon
    - Wrong icon replaced with correct one.
- FIX display `g` instead of `grams`
- FIX patient card age formatting
    - Up to 3 months display age in weeks.
    - Up to 2 years display age in months.
- UPD skip medical history items when not filled in  …
    - Following designer's request medical history items are now not listed at all if they were not filled in.

- Related: #185